### PR TITLE
Fix #49

### DIFF
--- a/src/main/java/org/protelis/vm/util/CodePath.java
+++ b/src/main/java/org/protelis/vm/util/CodePath.java
@@ -8,28 +8,45 @@
  *******************************************************************************/
 package org.protelis.vm.util;
 
-import static org.danilopianini.lang.Constants.DJB2_MAGIC;
 import gnu.trove.list.TByteList;
 
 import java.io.Serializable;
 import java.util.Arrays;
 
-import org.danilopianini.lang.Constants;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
 
 /**
- * A CodePath is a trace from the root to some node in a VM execution tree.
- * Its use is to allow particular execution locations to be serialized and compared between
- * different VMs, thereby enabling code alignment.  Importantly, the hashCode can be
- * used to uniquely identify CodePath objects, allowing lightweight transmission and comparison.
+ * A CodePath is a trace from the root to some node in a VM execution tree. Its
+ * use is to allow particular execution locations to be serialized and compared
+ * between different VMs, thereby enabling code alignment. Importantly, the
+ * hashCode can be used to uniquely identify CodePath objects, allowing
+ * lightweight transmission and comparison.
  */
 public class CodePath implements Serializable {
 
 	private static final long serialVersionUID = 5914261026069038877L;
+	private static final HashFunction HASH_FUNCTION = Hashing.murmur3_32();
+	private static final int INT_MASK = 0xFF;
+	private static final long LONG_MASK = 0xFF;
 	private static final int ENCODING_BASE = 36;
+	private static final int BITS_PER_BYTE = 8;
+	/**
+	 * This sequence of longs will be filled with the bytes representing the
+	 * execution trace. The choice of a long[] is targeted at obtaining the best
+	 * possible performance. Java can not store bytes (they are converted to
+	 * int), but is pretty efficient with int[] and long[].
+	 */
 	private final long[] path;
 	private final int size;
+	/**
+	 * This flag switches to true when there are four or less numerical markers.
+	 * In this case, in fact, an int is big enough to include them all, without
+	 * losing any data.
+	 */
 	private final boolean safe;
-	private int hash;
+	private final int hash;
 	private String string;
 
 	/**
@@ -40,21 +57,57 @@ public class CodePath implements Serializable {
 		size = stack.size();
 		safe = size < 4;
 		if (safe) {
+			/*
+			 * Very short stack, an int suffices.
+			 */
 			path = null;
+			int tempHash = 0;
 			for (int i = 0; i < stack.size(); i++) {
-				hash |= (-1 & stack.get(i)) << 8 * i;
+				/*
+				 * Suppose we have bytes [1, 2, 3].
+				 * 
+				 * First, we map the byte to an int, using the operation
+				 * described in the comment above. Our first byte, which is the
+				 * hex number 0x01, becomes 0x00000001. Then, we shift the byte
+				 * towards left of 0 positions (so it remains exactly equal) and
+				 * then join it with the current 0x00000000 result through a or
+				 * operator, so that the current result is 0x00000001.
+				 * 
+				 * Our second byte is 0x02. It becomes 0x00000002 first, then
+				 * gets shifted of 8 bits, namely of two positions in
+				 * hexadecimal notation. It becomes 0x00000200, and gets
+				 * combined with the current result (0x00000001) with an or, so
+				 * the current result becomes 0x00000201.
+				 * 
+				 * At the end of our procedure, when the third value has been
+				 * processed, the resulting value is 0x00030201
+				 * 
+				 */
+				tempHash |= (stack.get(i) & INT_MASK) << (BITS_PER_BYTE * i);
 			}
+			hash = tempHash;
 		} else {
-			path = new long[(stack.size() + 7) / 8];
-			hash = Constants.DJB2_START;
+			final Hasher hashGen = HASH_FUNCTION.newHasher(size);
+			path = new long[(stack.size() - 1) / Long.BYTES + 1];
+			/*
+			 * Here, we run across all the bytes, and we do two operations at
+			 * the same time:
+			 * 
+			 * 1) We feed our hasher
+			 * 
+			 * 2) We fill the long[]. This long[] is filled using a strategy
+			 * very similar to the one used above for the int hash in case of
+			 * size < 4.
+			 */
 			for (int i = 0; i < stack.size(); i++) {
 				final byte b = stack.get(i);
-				hash = hash * DJB2_MAGIC ^ b;
-				path[i / 8] |= ((0L | b) << 56 >>> 56) << 8 * (i % 8);
+				hashGen.putByte(b);
+				path[i / Long.BYTES] |= (b & LONG_MASK) << (BITS_PER_BYTE * (i % Long.BYTES));
 			}
+			hash = hashGen.hash().asInt();
 		}
 	}
-
+	
 	@Override
 	public int hashCode() {
 		return hash;
@@ -88,6 +141,18 @@ public class CodePath implements Serializable {
 			string = sb.toString();
 		}
 		return string;
+	}
+	
+	/**
+	 * @return a representation of this path as a long array. The returned array
+	 *         is a defensive copy, i.e. changes to the returned array will NOT
+	 *         modify this object
+	 */
+	public long[] asLongArray() {
+		if (safe) {
+			return new long[]{hash};
+		}
+		return Arrays.copyOf(path, path.length);
 	}
 
 }

--- a/src/test/java/org/protelis/test/TestCodePath.java
+++ b/src/test/java/org/protelis/test/TestCodePath.java
@@ -1,0 +1,57 @@
+package org.protelis.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+import org.protelis.vm.util.CodePath;
+
+import gnu.trove.list.array.TByteArrayList;
+
+/**
+ *
+ */
+public class TestCodePath {
+
+	private static final long[] MASKS = new long[] {
+			0xFFL,
+			0xFF00L,
+			0xFF0000L,
+			0xFF000000L,
+			0xFF00000000L,
+			0xFF0000000000L,
+			0xFF000000000000L,
+			0xFF00000000000000L
+	};
+
+	
+	private static void initCodePathAndTest(final byte... input) {
+		final CodePath underTest = new CodePath(new TByteArrayList(input));
+		final long[] res = underTest.asLongArray();
+		for (int i = 0; i < input.length; i++) {
+			final int lidx = i / Long.BYTES;
+			final int midx = i % Long.BYTES;
+			assertEquals((byte) ((res[lidx] & MASKS[midx]) >>> (midx * 8)), input[i]);
+		}
+	}
+	
+	/**
+	 * 
+	 */
+	@Test
+	public void test() {
+		final Random rnd = new Random(0);
+		IntStream.range(0, 1000).forEach(i -> {
+			final byte[] test = new byte[i];
+			for (int j = 0; j < test.length; j++) {
+				test[j] = (byte) rnd.nextInt();
+			}
+			Arrays.toString(test);
+			initCodePathAndTest(test);
+		});
+	}
+
+}


### PR DESCRIPTION
* Changed magic numbers to meaningful things
* Fixed bug with codepaths shorter than 4 elements
* Replaced double shifting with bitwise and filtering
* Switched from unicorn-magic-djb2 to Google Guava's MurmurHash3 32bit
* Add view of codepath as long[]
* Add test