### PR TITLE
Critical bug in AlignedMap

### DIFF
--- a/src/main/java/org/protelis/lang/interpreter/impl/AlignedMap.java
+++ b/src/main/java/org/protelis/lang/interpreter/impl/AlignedMap.java
@@ -150,12 +150,12 @@ public class AlignedMap extends AbstractSATree<Map<Object, Pair<DotOperator, Dot
             final List<AnnotatedTree<?>> args = new ArrayList<>(2);
             args.add(new Constant<>(key));
             args.add(new Variable(CURFIELD));
-            context.putVariable(CURFIELD, value, true);
+            restricted.putVariable(CURFIELD, value, true);
             /*
              * Compute the code path: align on keys
              */
             final byte[] hash = FileUtilities.serializeObject((Serializable) key);
-            context.newCallStackFrame(hash);
+            restricted.newCallStackFrame(hash);
             /*
              * Compute functions if needed
              */
@@ -167,19 +167,19 @@ public class AlignedMap extends AbstractSATree<Map<Object, Pair<DotOperator, Dot
              * Run the actual filtering and operation
              */
             final DotOperator fop = funs.getFirst();
-            context.newCallStackFrame(FILTER_POS);
+            restricted.newCallStackFrame(FILTER_POS);
             fop.eval(restricted);
-            context.returnFromCallFrame();
+            restricted.returnFromCallFrame();
             final Object cond = fop.getAnnotation();
             if (cond instanceof Boolean) {
                 if ((Boolean) cond) {
                     /*
                      * Filter passed, run operation.
                      */
-                    context.newCallStackFrame(RUN_POS);
+                    restricted.newCallStackFrame(RUN_POS);
                     final DotOperator rop = funs.getSecond();
                     rop.eval(restricted);
-                    context.returnFromCallFrame();
+                    restricted.returnFromCallFrame();
                     resl.add(Tuple.create(key, rop.getAnnotation()));
                     /*
                      * If both the key exists and the filter passes, save the
@@ -190,7 +190,7 @@ public class AlignedMap extends AbstractSATree<Map<Object, Pair<DotOperator, Dot
             } else {
                 throw new IllegalStateException("Filter must return a Boolean, got " + cond.getClass());
             }
-            context.returnFromCallFrame();
+            restricted.returnFromCallFrame();
         }
         // return type: [[key0, compval0], [key1, compval1], [key2, compval2]]
         setAnnotation(Tuple.create(resl));

--- a/src/main/java/org/protelis/vm/impl/AbstractExecutionContext.java
+++ b/src/main/java/org/protelis/vm/impl/AbstractExecutionContext.java
@@ -148,6 +148,7 @@ public abstract class AbstractExecutionContext implements ExecutionContext {
         restrictedInstance.theta = restricted;
         restrictedInstance.gamma = gamma;
         restrictedInstance.toSend = toSend;
+        restrictedInstance.callStack.addAll(callStack);
         return restrictedInstance;
     }
 


### PR DESCRIPTION
Stressing enough the AlignedMap exposed a critical bug in the alignment on keys. Those two commits should fix it.
The bug was subtle and double edged:
* AbstractContext was not reproducing the existing code path when creating a new restriction: that was triggering errors in my current experiments
* AlignedMap was using the parent context rather than the restricted one in the first call: I found this while debugging the other issue, it may cause a filtering operation containing a nbr to align with the subsequent execution operation.