### PR TITLE
Access ExecutionEnvironment keys

### DIFF
--- a/protelis/protelis-interpreter/src/main/java/org/protelis/vm/ExecutionEnvironment.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/vm/ExecutionEnvironment.java
@@ -1,5 +1,7 @@
 package org.protelis.vm;
 
+import java.util.Set;
+
 /**
  * The {@link ExecutionEnvironment} is responsible of managing environment variables.
  *
@@ -46,6 +48,11 @@ public interface ExecutionEnvironment {
      *         key, or null if the map contained no mapping for the key.
      */
     Object remove(String id);
+
+    /**
+     * @return An unmodifiable set of the keys in the ExecutionEnvironment
+     */
+    Set<String> keySet();
 
     /**
      * Called just after the VM is executed, to finalize information of the

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/SimpleExecutionEnvironment.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/SimpleExecutionEnvironment.java
@@ -1,12 +1,10 @@
 package org.protelis.vm.impl;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.danilopianini.lang.util.FasterString;
 import org.protelis.vm.ExecutionEnvironment;
 
 /**
@@ -16,23 +14,22 @@ import org.protelis.vm.ExecutionEnvironment;
  */
 public final class SimpleExecutionEnvironment implements ExecutionEnvironment {
 
-    private final Map<FasterString, Object> env = new LinkedHashMap<>();
-    private final Set<String> keys = new HashSet<>();
+    private final Map<String, Object> env = new LinkedHashMap<>();
 
     @Override
     public boolean has(final String id) {
-        return env.containsKey(new FasterString(id));
+        return env.containsKey(id);
     }
 
     @Override
     public Object get(final String id) {
-        return env.get(new FasterString(id));
+        return env.get(id);
     }
 
     @Override
     public Object get(final String id, final Object defaultValue) {
         if (has(id)) {
-            return env.get(new FasterString(id));
+            return env.get(id);
         } else {
             return defaultValue;
         }
@@ -40,19 +37,17 @@ public final class SimpleExecutionEnvironment implements ExecutionEnvironment {
 
     @Override
     public boolean put(final String id, final Object v) {
-        keys.add(id);
-        return env.put(new FasterString(id), v) != null;
+        return env.put(id, v) != null;
     }
 
     @Override
     public Object remove(final String id) {
-        keys.remove(id);
-        return env.remove(new FasterString(id));
+        return env.remove(id);
     }
 
     @Override
     public Set<String> keySet() {
-        return Collections.unmodifiableSet(keys);
+        return Collections.unmodifiableSet(env.keySet());
     }
 
     @Override

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/SimpleExecutionEnvironment.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/SimpleExecutionEnvironment.java
@@ -1,7 +1,10 @@
 package org.protelis.vm.impl;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.danilopianini.lang.util.FasterString;
 import org.protelis.vm.ExecutionEnvironment;
@@ -14,6 +17,7 @@ import org.protelis.vm.ExecutionEnvironment;
 public final class SimpleExecutionEnvironment implements ExecutionEnvironment {
 
     private final Map<FasterString, Object> env = new LinkedHashMap<>();
+    private final Set<String> keys = new HashSet<>();
 
     @Override
     public boolean has(final String id) {
@@ -36,12 +40,19 @@ public final class SimpleExecutionEnvironment implements ExecutionEnvironment {
 
     @Override
     public boolean put(final String id, final Object v) {
+        keys.add(id);
         return env.put(new FasterString(id), v) != null;
     }
 
     @Override
     public Object remove(final String id) {
+        keys.remove(id);
         return env.remove(new FasterString(id));
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return Collections.unmodifiableSet(keys);
     }
 
     @Override

--- a/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/ProtelisNode.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/ProtelisNode.java
@@ -1,6 +1,9 @@
 package org.protelis.test.infrastructure;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 import org.protelis.lang.datatype.DeviceUID;
 import org.protelis.vm.ExecutionEnvironment;
@@ -96,6 +99,16 @@ public class ProtelisNode extends GenericNode<Object> implements DeviceUID, Exec
      */
     public NetworkManager getNetworkManager() {
         return netmgr;
+    }
+
+    @Override
+    public Set<String> keySet() {
+        Set<String> sSet = new HashSet<String>();
+        // Note: this is highly inefficient
+        for (Molecule key : getContents().keySet()) {
+            sSet.add(key.getName());
+        }
+        return Collections.unmodifiableSet(sSet);
     }
 
 }


### PR DESCRIPTION
Proposed fix for Issue #120: ExecutionEnvironment now provides access to an unmodifiable set of the keys in the environment.  

The complexity here is that SimpleExecutionEnvironment uses FasterString, rather than String for its keys.  I saw three ways to address this: either by changing its internals, by converting on call, or keeping a parallel set. Since the key concern is access speed, I decided to keep a parallel set.  The alternate approach of changing its internals from FasterString to String seems plausible too.