### PR TITLE
Base implementation for ChildExecutionContext

### DIFF
--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/Self.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/Self.java
@@ -9,6 +9,7 @@
 package org.protelis.lang.interpreter.impl;
 
 import org.protelis.vm.ExecutionContext;
+import org.protelis.vm.impl.ChildExecutionContext;
 
 /**
  * Access to the evaluation context, which is used for interfacing with sensors,
@@ -26,7 +27,11 @@ public class Self extends AbstractAnnotatedTree<ExecutionContext> {
 
     @Override
     public void eval(final ExecutionContext context) {
-        setAnnotation(context);
+        if (context instanceof ChildExecutionContext) {
+            eval(((ChildExecutionContext) context).getParent());
+        } else {
+            setAnnotation(context);
+        }
     }
 
     @Override

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/AbstractExecutionContext.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/AbstractExecutionContext.java
@@ -145,7 +145,9 @@ public abstract class AbstractExecutionContext implements ExecutionContext {
      * 
      * @return Child execution context
      */
-    protected abstract AbstractExecutionContext instance();
+    protected AbstractExecutionContext instance() {
+        return new ChildExecutionContext(this);
+    }
 
     @Override
     public final AbstractExecutionContext restrictDomain(final Field f) {

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/ChildExecutionContext.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/ChildExecutionContext.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (C) 2010, 2015, Danilo Pianini and contributors
+ * listed in the project's build.gradle or pom.xml file.
+ *
+ * This file is part of Protelis, and is distributed under the terms of
+ * the GNU General Public License, with a linking exception, as described
+ * in the file LICENSE.txt in this project's top directory.
+ *******************************************************************************/
+package org.protelis.vm.impl;
+
+import org.protelis.lang.datatype.DeviceUID;
+
+/**
+ * Child context is used by AbstractExecutionContext.instance() to allow 
+ * encapsulated evaluation of sub-programs, while passing through "self" 
+ * accesses to its parent.
+ */
+public class ChildExecutionContext extends AbstractExecutionContext {
+    private AbstractExecutionContext parent;
+
+    /**
+     * Create a new child context.
+     * @param parent the parent execution context to get information from.
+     */
+    public ChildExecutionContext(final AbstractExecutionContext parent) {
+        super(parent.getExecutionEnvironment(), parent.getNetworkManager());
+        this.parent = parent;
+    }
+
+    /** @return parent for this child context */
+    public AbstractExecutionContext getParent() {
+        return parent;
+    }
+
+    @Override
+    protected AbstractExecutionContext instance() {
+        return new ChildExecutionContext(parent);
+    }
+
+    @Override
+    public DeviceUID getDeviceUID() {
+        return parent.getDeviceUID();
+    }
+
+    @Override
+    public Number getCurrentTime() {
+        return parent.getCurrentTime();
+    }
+
+    @Override
+    public double nextRandomDouble() {
+        return parent.nextRandomDouble();
+    }
+}

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/ChildExecutionContext.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/ChildExecutionContext.java
@@ -16,7 +16,7 @@ import org.protelis.lang.datatype.DeviceUID;
  * accesses to its parent.
  */
 public class ChildExecutionContext extends AbstractExecutionContext {
-    private AbstractExecutionContext parent;
+    private final AbstractExecutionContext parent;
 
     /**
      * Create a new child context.

--- a/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyContext.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyContext.java
@@ -73,11 +73,6 @@ public final class DummyContext extends AbstractExecutionContext {
     }
 
     @Override
-    protected AbstractExecutionContext instance() {
-        return new DummyContext();
-    }
-
-    @Override
     public String toString() {
         return getClass().getSimpleName() + hashCode();
     }

--- a/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyDevice.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyDevice.java
@@ -26,7 +26,6 @@ public class DummyDevice extends AbstractExecutionContext
     private final ProtelisNode node;
     private final Environment<Object> env;
     private final Reaction<Object> react;
-    private final NetworkManager netmgr;
 
     /**
      * 
@@ -47,7 +46,6 @@ public class DummyDevice extends AbstractExecutionContext
         r = random;
         this.react = reaction;
         this.env = environment;
-        this.netmgr = netmgr;
         this.node = node;
     }
 

--- a/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyDevice.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyDevice.java
@@ -76,11 +76,6 @@ public class DummyDevice extends AbstractExecutionContext
         return 1;
     }
 
-    @Override
-    protected AbstractExecutionContext instance() {
-        return new DummyDevice(env, node, react, r, netmgr);
-    }
-
     /**
      * Note: this should be going away in the future, to be replaced by standard
      * Java random.


### PR DESCRIPTION
AbstractExecutionContext.instance() has been problematic, because the "child" contexts are easy to screw up and don't interact cleanly with "self".  This patch adds a base "ChildExecutionContext" class that is the default used for creating instances; furthermore, when "self" encounters a ChildExecutionContext, is traces it up to its parent for making calls.