### PR TITLE
Null and Option in Protelis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,13 @@ env:
     - secure: "I4+Yjiu5Y5khd4MzFtY5UP2P+L72wklqgZ4uDNhQ+RJeIgOmbKit0tluWda/KpFVEC9K+SuGLURtzsL9XnmiBRbPdOaB/a6cJPW4TUzmpxbyu4Zl2OlcqngVOBku7al+54cMergdXFK0eflXlDik/8RH0stOd79tPoyDerdfUhoy1Tbdi0F014UBhHM4YraB7Tcunchw4InjcEWBtLY7VZMyw1CCeajf9r7ucXRyUnSjAjvR7jPVKg4+yiCefkC45xR0sok0cHec/HjDw9HReV40PkBNmTSTT8qjWPgH118zzMWR38B7gVvOIvPG549939yHv/q94VIIKn0ZDFwtk2CtcyX4HD35QM/EmfBHboEq55ckmSuz3L48X+C78697+4lZ4aa7/30y8TJIEiDeuAmNtvXAvf7zio+3lZs5OpyEAbHlpvt8ggzutrG6o9EskfgJ8c5g3zLP3/Q8OtefqR3DWArNNMpYk6UpL7JEN8LekloCOofM1XZh21ucqss+k1MC5IG3o9sCIs9ToW3CX9Kf9LGtpYhbnQPCNw9BBUxuIaignXOODGdYxjMmDQyZ+s1+mJr2WxHmmMxyu+TBFh5H9few26JDNWxO4+C2Ql95qlL9zUiRQFWsR3eOAqzbshY0yhTju0vIrsxxqxK+gtXij9jnKAfjvD3/Ai3bnIQ="
     - secure: "hhegqLy8o3Q0SJXFX5fqnixwQyADBNv5NSotuXEFf3qsb1/0CvGu+0rFkP0z+Aq5p8amv71NTl7KHvcpGodpNl28HYjbsfg3wbszdJIJuyX6fGxxMdaegb++coSU6mav9Of7zKbeg+uoE/qkE/CpGeak5L872xM3TiS0mA4+Eer3hArHDHt5zAzsUkEkZCgiuMYhUXopYB7BX1N/c/E3Sj8fD2yryDa4mfs5kaXChAbi/k4A6+CsScaF+F7v1XKaoJRy2PgYw28V9AsHr5Y6DwBYyGloZUGAWAcc6qHZaJqcO2ltVSAT1duTOi6kEy7Mvxyv4buj3hhMbq1OpINukCSKfLwwj3+gQOiOCDAmMIJPm/mJzjMS+puMu0+5K3bCRq2IrjyGkP6ZOflINaF6Pi4djBpZp2+ksTSdO73hJYSu6PltXS/XTEEocQYxvFM4cXNy1clxvMFI0aoC0Ihc7GdVheDbO0A1bJ0y9bxGEb0fYrEH1RyDvzxV4mXZFG8x9M4+sKhyIU7Et4dGB9d/YQCVp00//POOdKeXSlXFR/6SOp4eRga/G6S3a6aBJDcO7maiwC4rt9r6fPotGZvYuFRbVG4U2XvhW65V5LY4UVniGz5nBNu/EksMg5ULBMp+1IhJ79cMjotzj+pNvUwpBml6CbNzSYGY1BUUrIVZy9E="
   matrix:
-    - PUBLISH=false
+    - PUBLISH="false"
 
 matrix:
   include:
     - jdk: openjdk8
       env: PUBLISH="true"
+      os: linux
   exclude:
     - jdk: openjdk8
       env: PUBLISH="false"

--- a/protelis/build.gradle.kts
+++ b/protelis/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     pmd
     checkstyle
     id("org.jlleitschuh.gradle.ktlint") version Versions.org_jlleitschuh_gradle_ktlint_gradle_plugin
-    id("org.protelis.protelisdoc") version "0.1.1-dev08+b8184c8"
+//    id("org.protelis.protelisdoc") version "0.1.1-dev08+b8184c8"
     signing
     `maven-publish`
     id("org.danilopianini.publish-on-central") version Versions.org_danilopianini_publish_on_central_gradle_plugin
@@ -38,7 +38,7 @@ allprojects {
     apply(plugin = "checkstyle")
     apply(plugin = "pmd")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
-    apply(plugin = "org.jetbrains.kotlin.jvm")
+//    apply(plugin = "org.jetbrains.kotlin.jvm")
 //    apply(plugin = "org.protelis.protelisdoc")
     apply(plugin = "project-report")
     apply(plugin = "build-dashboard")

--- a/protelis/build.gradle.kts
+++ b/protelis/build.gradle.kts
@@ -77,7 +77,6 @@ allprojects {
     }
 
     spotbugs {
-        isIgnoreFailures = true
         effort = "max"
         reportLevel = "low"
         val excludeFile = File("${project.rootProject.projectDir}/config/spotbugs/excludes.xml")

--- a/protelis/buildSrc/src/main/kotlin/Libs.kt
+++ b/protelis/buildSrc/src/main/kotlin/Libs.kt
@@ -52,6 +52,10 @@ object Libs {
     const val fst: String = "de.ruedigermoeller:fst:" + Versions.fst
 
     /**
+     * https://github.com/classgraph/classgraph */
+    const val classgraph: String = "io.github.classgraph:classgraph:" + Versions.classgraph
+
+    /**
      * https://github.com/AlchemistSimulator/alchemist-interfaces */
     const val alchemist_interfaces: String = "it.unibo.alchemist:alchemist-interfaces:" +
             Versions.it_unibo_alchemist
@@ -116,11 +120,6 @@ object Libs {
     const val org_protelis_protelisdoc_gradle_plugin: String =
             "org.protelis.protelisdoc:org.protelis.protelisdoc.gradle.plugin:" +
             Versions.org_protelis_protelisdoc_gradle_plugin
-
-    /**
-     * https://github.com/Protelis/protelis-interpreter */
-    const val protelis_interpreter: String = "org.protelis:protelis-interpreter:" +
-            Versions.protelis_interpreter
 
     /**
      * http://protelis.org */

--- a/protelis/buildSrc/src/main/kotlin/Versions.kt
+++ b/protelis/buildSrc/src/main/kotlin/Versions.kt
@@ -19,7 +19,7 @@ object Versions {
 
     const val com_jfrog_bintray_gradle_plugin: String = "1.8.4" 
 
-    const val ktlint: String = "0.32.0" 
+    const val ktlint: String = "0.32.0" // available: "0.33.0"
 
     const val commons_codec: String = "1.12" 
 
@@ -28,6 +28,8 @@ object Versions {
     const val de_fayard_buildsrcversions_gradle_plugin: String = "0.3.2" 
 
     const val fst: String = "2.57" 
+
+    const val classgraph: String = "4.8.37" 
 
     const val it_unibo_alchemist: String = "4.0.0" // available: "8.0.0-beta+0t3.1fcab"
 
@@ -57,7 +59,7 @@ object Versions {
 
     const val org_protelis_protelisdoc_gradle_plugin: String = "0.1.1-dev08+b8184c8" // available: "0.1.1"
 
-    const val protelis_interpreter: String = "12.0.0" 
+    const val protelis_interpreter: String = "12.1.0" 
 
     const val protelis_parser: String = "9.1.0" 
 
@@ -75,8 +77,8 @@ object Versions {
 
         const val currentVersion: String = "5.4.1"
 
-        const val nightlyVersion: String = "5.6-20190528000143+0000"
+        const val nightlyVersion: String = "5.6-20190605000047+0000"
 
-        const val releaseCandidate: String = ""
+        const val releaseCandidate: String = "5.5-rc-1"
     }
 }

--- a/protelis/config/spotbugs/excludes.xml
+++ b/protelis/config/spotbugs/excludes.xml
@@ -14,4 +14,7 @@
     <Match>
         <Bug pattern="OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE" />
     </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+    </Match>
 </FindBugsFilter>

--- a/protelis/config/spotbugs/excludes.xml
+++ b/protelis/config/spotbugs/excludes.xml
@@ -1,15 +1,23 @@
-<!--
-  ~ Copyright (C) 2010-2019, Danilo Pianini and contributors listed in the main project's alchemist/build.gradle file.
-  ~
-  ~ This file is part of Alchemist, and is distributed under the terms of the
-  ~ GNU General Public License, with a linking exception,
-  ~ as described in the file LICENSE in the Alchemist distribution's top directory.
-  -->
+<!-- ~ Copyright (C) 2010-2019, Danilo Pianini and contributors listed in 
+	the main project's alchemist/build.gradle file. ~ ~ This file is part of 
+	Alchemist, and is distributed under the terms of the ~ GNU General Public 
+	License, with a linking exception, ~ as described in the file LICENSE in 
+	the Alchemist distribution's top directory. -->
 
 <FindBugsFilter>
 	<Match>
 		<Bug pattern="CN_IDIOM_NO_SUPER_CALL" />
+	</Match>
+	<Match>
 		<Bug pattern="IMA_INEFFICIENT_MEMBER_ACCESS" />
+	</Match>
+	<Match>
 		<Bug pattern="SE_INNER_CLASS" />
 	</Match>
+    <Match>
+        <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD" />
+    </Match>
+    <Match>
+        <Bug pattern="OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE" />
+    </Match>
 </FindBugsFilter>

--- a/protelis/config/spotbugs/excludes.xml
+++ b/protelis/config/spotbugs/excludes.xml
@@ -1,9 +1,3 @@
-<!-- ~ Copyright (C) 2010-2019, Danilo Pianini and contributors listed in 
-	the main project's alchemist/build.gradle file. ~ ~ This file is part of 
-	Alchemist, and is distributed under the terms of the ~ GNU General Public 
-	License, with a linking exception, ~ as described in the file LICENSE in 
-	the Alchemist distribution's top directory. -->
-
 <FindBugsFilter>
 	<Match>
 		<Bug pattern="CN_IDIOM_NO_SUPER_CALL" />

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/ProtelisLoader.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/ProtelisLoader.java
@@ -748,7 +748,7 @@ public final class ProtelisLoader {
         private ProgramState(final Map<Reference, FunctionDefinition> functions) {
             this.functions = functions;
         }
-        FunctionDefinition resolveFunction(final Reference r) {
+        private FunctionDefinition resolveFunction(final Reference r) {
             return functions.get(r);
         }
     }

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/ProtelisLoader.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/ProtelisLoader.java
@@ -547,19 +547,14 @@ public final class ProtelisLoader {
                 final boolean inclusive = hood.getName().length() > 4;
                 final AnnotatedTree<?> nullResult = expression(hood.getDefault(), state);
                 final AnnotatedTree<Field> field = expression(hood.getArg(), state);
-                final EObject ref = hood.getReference();
+                final VarUse ref = hood.getReference();
                 if (ref == null) {
                     return new GenericHoodCall(meta, inclusive, lambda(hood.getOp(), state), nullResult, field);
                 }
-                if (ref instanceof VarUse) {
-                    final VarUse refVar = (VarUse) ref;
-                    if (refVar.getReference() instanceof JvmOperation) {
-                        return new GenericHoodCall(meta, inclusive, (JvmOperation) refVar.getReference(), nullResult, field);
-                    }
-                    return new GenericHoodCall(meta, inclusive, variableUnsafe(refVar), nullResult, field);
-                } else {
-                    throw new IllegalStateException("Unexpected type of function in hood call: " + ref.getClass());
+                if (ref.getReference() instanceof JvmOperation) {
+                    return new GenericHoodCall(meta, inclusive, (JvmOperation) ref.getReference(), nullResult, field);
                 }
+                return new GenericHoodCall(meta, inclusive, variableUnsafe(ref), nullResult, field);
             }
             if (expression instanceof Mux) {
                 final Mux mux = (Mux) expression;

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/Option.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/Option.java
@@ -1,0 +1,281 @@
+package org.protelis.lang.datatype;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.protelis.lang.interpreter.util.JavaInteroperabilityUtils;
+import org.protelis.vm.ExecutionContext;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class Option<E> {
+
+    private static final Option<Object> EMPTY = new Option<>(null);
+    private static final ImmutableMap<String, Boolean> TESTERS = ImmutableMap.of(
+            "isPresent", true,
+            "isNotPresent", false,
+            "isEmpty", false,
+            "isAbsent", false);
+    private final Optional<E> internal;
+
+    private Option() {
+        this(null);
+    }
+
+    private Option(E o) {
+        internal = Optional.fromNullable(o); 
+    }
+
+    public Set<E> asSet() {
+        return internal.asSet();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj == this || internal.equals(((Option<?>) obj).internal);
+    }
+
+    public Option<E> filter(ExecutionContext ctx, FunctionDefinition test) {
+        return runProtelis(ctx, test, value -> {
+            if (value instanceof Boolean) {
+                boolean condition = (boolean) value;
+                if (condition) {
+                    return this;
+                }
+                return empty();
+            }
+            throw new IllegalStateException("Filter functions must return boolean. Illegal: " + test);
+        });
+    }
+
+    public Option<E> filterNot(ExecutionContext ctx, FunctionDefinition test) {
+        return filter(ctx, test).isEmpty() ? this : empty();
+    }
+
+    public Option<E> filter(Predicate<? super E> test) {
+        if (isPresent() && test.test(get())) {
+            return this;
+        }
+        return empty();
+    }
+
+    public Option<E> filterNot(Predicate<? super E> test) {
+        return filter(e -> !test.test(e));
+    }
+
+    @SuppressWarnings("unchecked")
+    public <X> Option<X> flatMap(ExecutionContext ctx, FunctionDefinition fun) throws IllegalAccessException, InvocationTargetException {
+        runProtelis(ctx, fun, value -> {
+            if (value instanceof Option) {
+                final Option<?> result = (Option<?>) value;
+                if (result.isEmpty()) {
+                    return Option.<X>empty();
+                }
+                return (Option<X>) value;
+            } else if (value instanceof Optional) {
+                final Optional<?> result = (Optional<?>) value;
+                if (result.isPresent()) {
+                    return new Option<X>((X) result.get());
+                }
+                return Option.<X>empty();
+            } else if (value instanceof java.util.Optional) {
+                final java.util.Optional<?> result = (java.util.Optional<?>) value;
+                if (result.isPresent()) {
+                    return new Option<X>((X) result.get());
+                }
+                return Option.<X>empty();
+            } else {
+                /*
+                 * Attempt with structural typing. In case of failure, give up.
+                 */
+                final List<Method> methods = Arrays.stream(value.getClass().getMethods())
+                    .map(MethodUtils::getAccessibleMethod)
+                    .filter(it -> it != null)
+                    .collect(Collectors.toList());
+                final Method tester = methods.stream()
+                    .filter(it -> it.getParameterCount() == 0)
+                    .filter(it -> it.getReturnType().equals(Boolean.class) || it.getReturnType().equals(boolean.class))
+                    .filter(it -> TESTERS.containsKey(it.getName()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("No method in " + value.getClass()
+                        + " has name in " + TESTERS.keySet()
+                        + ", expects no parameter, and returns boolean."));
+                boolean isPresent;
+                try {
+                    isPresent = (boolean) tester.invoke(value);
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    throw new IllegalStateException(e);
+                }
+                if (isPresent) {
+                    final Method getter = methods.stream()
+                        .filter(it -> it.getParameterCount() == 0)
+                        .filter(it -> "get".equals(it.getName()))
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalStateException("No method in " + value.getClass() + " named get with no parameter"));
+                    Object result;
+                    try {
+                        result = getter.invoke(value);
+                    } catch (IllegalAccessException | InvocationTargetException e) {
+                        throw new IllegalStateException(e);
+                    }
+                    if (result == null) {
+                        throw new IllegalStateException(value + " is not empty, but its get() method returned null.");
+                    }
+                    return new Option<X>((X) result);
+                } else {
+                    return empty();
+                }
+            }
+        });
+        throw new IllegalArgumentException("Flat-mapping function must take one parameter and return Option.");
+    }
+
+    public <X> Option<X> flatMap(Function<? super E, Option<X>> fun) {
+        if (isPresent()) {
+            return fun.apply(get());
+        }
+        return empty();
+    }
+
+    public E get() {
+        if (isPresent()) {
+            return internal.get();
+        }
+        throw new NullPointerException("Cannot access value of empty Option");
+    }
+
+    @Override
+    public int hashCode() {
+        return internal.hashCode();
+    }
+
+    public void ifPresent(Consumer<? super E> consumer) {
+        if (isPresent()) {
+            consumer.accept(get());
+        }
+    }
+
+    public Object ifPresent(ExecutionContext ctx, FunctionDefinition consumer) {
+        return runProtelis(ctx, consumer, Option::of)
+            .orElseThrow(() -> new IllegalStateException("ifPresent must bind to a valid value. Problematic function: " + consumer));
+    }
+
+    public boolean isAbsent() {
+        return isEmpty();
+    }
+
+    public boolean isEmpty() {
+        return !isPresent();
+    }
+
+    public boolean isPresent() {
+        return internal.isPresent();
+    }
+
+    public Option<Object> map(ExecutionContext ctx, FunctionDefinition mapper) {
+        return runProtelis(ctx, mapper, Option::of);
+    }
+
+    public <X> Option<X> map(Function<? super E,? extends X> mapper) {
+        return flatMap(it -> of(mapper.apply(it)));
+    }
+
+    public Object or(ExecutionContext ctx, FunctionDefinition other) {
+        return orElseGet(ctx, other);
+    }
+
+    public Option<? extends E> or(java.util.Optional<? extends E> other) {
+        return isPresent() ? this : other.map(Option::of).orElseGet(Option::empty);
+    }
+
+    public Option<? extends E> or(Option<? extends E> other) {
+        return isPresent() ? this : other;
+    }
+
+    public Option<? extends E> or(Optional<? extends E> other) {
+        return isPresent() ? this : of(other.orNull());
+    }
+
+    public E or(Supplier<? extends E> other) {
+        return orElseGet(other);
+    }
+
+    public E orElse(E other) {
+        return internal.or(other);
+    }
+
+    public Object orElseGet(ExecutionContext ctx, FunctionDefinition other) {
+        return ifPresent(ctx, other);
+    }
+
+    public E orElseGet(Supplier<? extends E> other) {
+        return internal.or(other.get());
+    }
+
+    public <X extends RuntimeException> E orElseThrow(Supplier<? extends X> exceptionSupplier) {
+        if (isPresent()) {
+            return get();
+        }
+        throw exceptionSupplier.get();
+    }
+
+    private <X> Option<X> runProtelis(ExecutionContext ctx, FunctionDefinition fun, Function<Object, Option<X>> converter) {
+        if (fun.getArgNumber() == 1) {
+            if (isPresent()) {
+                final Object value = JavaInteroperabilityUtils.runProtelisFunctionWithJavaArguments(ctx, fun, ImmutableList.of(get()));
+                return converter.apply(value);
+            }
+            return empty();
+        }
+        throw new IllegalArgumentException("Protelis function over Option take a single argument. Illegal: " + fun);
+    }
+
+    @Override
+    public String toString() {
+        return isEmpty() ? "Option.None" : "Option.Some(" + internal.get() + ')';
+    }
+
+    public Option<Object> transform(ExecutionContext ctx, FunctionDefinition mapper) {
+        return map(ctx, mapper);
+    }
+
+    public <X> Option<X> transform(Function<? super E,? extends X> mapper) {
+        return map(mapper);
+    }
+
+    public static <E> Option<E> absent() {
+        return empty();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E> Option<E> empty() {
+        return (Option<E>) EMPTY;
+    }
+
+    public static <E> Option<E> fromNullable(E o) {
+        return ofNullable(o);
+    }
+
+    public static Object none() {
+        return null;
+    }
+
+    public static <E> Option<E> of(E o) {
+        return new Option<>(o);
+    }
+
+    public static <E> Option<E> ofNullable(E o) {
+        return of(o);
+    }
+}

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/Option.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/Option.java
@@ -239,25 +239,23 @@ public final class Option<E> implements Serializable {
         return internal.hashCode();
     }
 
-    public void ifPresent(final Consumer<? super E> consumer) {
-        if (isPresent()) {
-            consumer.accept(get());
-        }
-    }
-
-    public Object ifPresent(final ExecutionContext ctx, final FunctionDefinition consumer) {
-        return runProtelis(ctx, consumer, Option::of)
-            .orElseThrow(() -> new IllegalStateException("ifPresent must bind to a valid value. Problematic function: " + consumer));
-    }
-
+    /**
+     * @return true if the Option has no value
+     */
     public boolean isAbsent() {
         return isEmpty();
     }
 
+    /**
+     * @return true if the Option has no value
+     */
     public boolean isEmpty() {
         return !isPresent();
     }
 
+    /**
+     * @return true if the Option is holding a value
+     */
     public boolean isPresent() {
         return internal.isPresent();
     }
@@ -294,8 +292,9 @@ public final class Option<E> implements Serializable {
         return internal.or(other);
     }
 
-    public Object orElseGet(final ExecutionContext ctx, final FunctionDefinition other) {
-        return ifPresent(ctx, other);
+    @SuppressWarnings("unchecked")
+    public E orElseGet(final ExecutionContext ctx, final FunctionDefinition other) {
+        return internal.or(() -> (E) JavaInteroperabilityUtils.runProtelisFunctionWithJavaArguments(ctx, other, ImmutableList.of()));
     }
 
     public E orElseGet(final Supplier<? extends E> other) {

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/Option.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/Option.java
@@ -37,8 +37,8 @@ import com.google.common.collect.ImmutableMap;
  */
 public final class Option<E> implements Serializable {
 
-    private static final long serialVersionUID = 1L;
     private static final Option<Object> EMPTY_OPTION = new Option<>(null);
+    private static final long serialVersionUID = 1L;
     private static final ImmutableMap<String, Boolean> TESTERS = ImmutableMap.of(
             "isPresent", true,
             "isNotPresent", false,
@@ -87,18 +87,6 @@ public final class Option<E> implements Serializable {
     }
 
     /**
-     * Inverse filter operation using Protelis functions.
-     * 
-     * @param ctx  the execution context
-     * @param test the function used as predicate. Must return boolean.
-     * @return If the test passes, the Option is emptied, otherwise, it's left
-     *         unchanged.
-     */
-    public Option<E> filterNot(final ExecutionContext ctx, final FunctionDefinition test) {
-        return filter(ctx, test).isEmpty() ? this : empty();
-    }
-
-    /**
      * @see java.util.Optional#filter(Predicate)
      * 
      * @param test predicate to test
@@ -111,6 +99,18 @@ public final class Option<E> implements Serializable {
             return this;
         }
         return empty();
+    }
+
+    /**
+     * Inverse filter operation using Protelis functions.
+     * 
+     * @param ctx  the execution context
+     * @param test the function used as predicate. Must return boolean.
+     * @return If the test passes, the Option is emptied, otherwise, it's left
+     *         unchanged.
+     */
+    public Option<E> filterNot(final ExecutionContext ctx, final FunctionDefinition test) {
+        return filter(ctx, test).isEmpty() ? this : empty();
     }
 
     /**
@@ -319,6 +319,14 @@ public final class Option<E> implements Serializable {
         throw new IllegalArgumentException("Protelis function over Option take a single argument. Illegal: " + fun);
     }
 
+    public Optional<E> toGuava() {
+        return internal;
+    }
+
+    public java.util.Optional<E> toJavaUtil() {
+        return internal.toJavaUtil();
+    }
+
     @Override
     public String toString() {
         return isEmpty() ? "Option.None" : "Option.Some(" + internal.get() + ')';
@@ -352,15 +360,7 @@ public final class Option<E> implements Serializable {
     public static <E> Option<E> of(final E o) {
         return new Option<>(o);
     }
-
     public static <E> Option<E> ofNullable(final E o) {
         return of(o);
-    }
-
-    public java.util.Optional<E> toJavaUtil() {
-        return internal.toJavaUtil();
-    }
-    public Optional<E> toGuava() {
-        return internal;
     }
 }

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/AbstractAnnotatedTree.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/AbstractAnnotatedTree.java
@@ -154,6 +154,13 @@ public abstract class AbstractAnnotatedTree<T> implements AnnotatedTree<T>, With
     }
 
     /**
+     * @return true if this node can get annotated with null values - namely, if it is an interaction with Java
+     */
+    protected boolean isNullable() {
+        return false;
+    }
+
+    /**
      * Facility to run lambdas across all the branches.
      * 
      * @param action
@@ -270,7 +277,8 @@ public abstract class AbstractAnnotatedTree<T> implements AnnotatedTree<T>, With
      *            the annotation to set
      */
     protected final void setAnnotation(final T obj) {
-        annotation = obj;
+        annotation = isNullable() ? obj : Objects.requireNonNull(obj, () -> 
+            this.getClass().getSimpleName() + " does not allow null return values. In: " + stringFor(this));
         erased = false;
     }
 

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/AbstractAnnotatedTree.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/AbstractAnnotatedTree.java
@@ -24,6 +24,7 @@ import org.protelis.lang.interpreter.util.WithBytecode;
 import org.protelis.lang.loading.Metadata;
 import org.protelis.vm.ExecutionContext;
 
+import java8.util.Optional;
 import java8.util.function.BiConsumer;
 import java8.util.function.Consumer;
 import java8.util.stream.IntStream;
@@ -318,6 +319,9 @@ public abstract class AbstractAnnotatedTree<T> implements AnnotatedTree<T>, With
      *         via {@link #getName()}
      */
     protected static final String stringFor(final AnnotatedTree<?> tree) {
-        return tree.isErased() ? tree.getName() : tree.getAnnotation().toString();
+        return Objects.requireNonNull(tree, "Impossible to convert a null AnnotatedTree to a String")
+            .isErased()
+                ? tree.getName()
+                : Optional.ofNullable(tree.getAnnotation()).map(Object::toString).orElse("null");
     }
 }

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/DotOperator.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/DotOperator.java
@@ -145,4 +145,9 @@ public final class DotOperator extends AbstractSATree<FunctionCall, Object> {
         return new DotOperator(target.getMetadata(), true, null, target, args);
     }
 
+    @Override
+    protected boolean isNullable() {
+        return true;
+    }
+
 }

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/If.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/If.java
@@ -9,6 +9,7 @@
 package org.protelis.lang.interpreter.impl;
 
 import org.protelis.lang.datatype.Field;
+import org.protelis.lang.datatype.Option;
 import org.protelis.lang.interpreter.AnnotatedTree;
 import org.protelis.lang.interpreter.util.Bytecode;
 import org.protelis.lang.loading.Metadata;
@@ -52,6 +53,7 @@ public final class If<T> extends AbstractAnnotatedTree<T> {
                 elseExpression == null ? null : elseExpression.copy());
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void evaluate(final ExecutionContext context) {
         projectAndEval(context);
@@ -59,8 +61,10 @@ public final class If<T> extends AbstractAnnotatedTree<T> {
         if (elseExpression == null) {
             if (isTrue) {
                 evalInNewStackFrame(thenExpression, context, Bytecode.IF_THEN);
+                setAnnotation(thenExpression.getAnnotation());
             } else {
                 thenExpression.erase();
+                setAnnotation((T) Option.empty());
             }
         } else {
             final AnnotatedTree<T> selected = isTrue ? thenExpression : elseExpression;

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/If.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/If.java
@@ -96,4 +96,9 @@ public final class If<T> extends AbstractAnnotatedTree<T> {
                 + stringFor(thenExpression) + " } else { " + stringFor(thenExpression) + '}';
     }
 
+    @Override
+    protected boolean isNullable() {
+        return elseExpression == null;
+    }
+
 }

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/MethodCall.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/MethodCall.java
@@ -151,4 +151,9 @@ public final class MethodCall extends AbstractAnnotatedTree<Object> {
                 .collect(Collectors.joining(", ", "(", ")"));
     }
 
+    @Override
+    protected boolean isNullable() {
+        return true;
+    }
+
 }

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/ShareCall.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/ShareCall.java
@@ -6,6 +6,8 @@ import static org.protelis.lang.interpreter.util.Bytecode.SHARE_BODY;
 import static org.protelis.lang.interpreter.util.Bytecode.SHARE_INIT;
 import static org.protelis.lang.interpreter.util.Bytecode.SHARE_YIELD;
 
+import javax.annotation.Nonnull;
+
 import org.protelis.lang.datatype.Field;
 import org.protelis.lang.interpreter.AnnotatedTree;
 import org.protelis.lang.interpreter.util.Bytecode;
@@ -50,12 +52,12 @@ public final class ShareCall<S, T> extends AbstractSATree<S, T> {
      *            body
      */
     public ShareCall(
-            final Metadata metadata,
-            final java8.util.Optional<Reference> localName,
-            final java8.util.Optional<Reference> fieldName,
-            final AnnotatedTree<?> init,
-            final AnnotatedTree<S> body,
-            final java8.util.Optional<AnnotatedTree<T>> yield) {
+            @Nonnull final Metadata metadata,
+            @Nonnull final java8.util.Optional<Reference> localName,
+            @Nonnull final java8.util.Optional<Reference> fieldName,
+            @Nonnull final AnnotatedTree<?> init,
+            @Nonnull final AnnotatedTree<S> body,
+            @Nonnull final java8.util.Optional<AnnotatedTree<T>> yield) {
         this(metadata, toGuava(localName), toGuava(fieldName), init, body, toGuava(yield));
     }
 
@@ -74,12 +76,12 @@ public final class ShareCall<S, T> extends AbstractSATree<S, T> {
      *            body
      */
     public ShareCall(
-            final Metadata metadata,
-            final Optional<Reference> localName,
-            final Optional<Reference> fieldName,
-            final AnnotatedTree<?> init,
-            final AnnotatedTree<S> body,
-            final Optional<AnnotatedTree<T>> yield) {
+            @Nonnull final Metadata metadata,
+            @Nonnull final Optional<Reference> localName,
+            @Nonnull final Optional<Reference> fieldName,
+            @Nonnull final AnnotatedTree<?> init,
+            @Nonnull final AnnotatedTree<S> body,
+            @Nonnull final Optional<AnnotatedTree<T>> yield) {
         super(metadata, init, body);
         if (!(localName.isPresent() || fieldName.isPresent())) {
             throw new IllegalArgumentException("Share cannot get initialized without at least a variable bind.");

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/util/HoodOp.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/util/HoodOp.java
@@ -105,7 +105,7 @@ public enum HoodOp implements WithBytecode {
           of(create(Object.class, DatatypeFactory::createTuple)));
 
     private final Bytecode bytecode;
-    private final SerializableFunction defs;
+    private final SerializableFunction defs; // NOPMD false positive, not a singular field
     private final SerializableBifunction function;
 
     /**

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/util/ReflectionUtils.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/util/ReflectionUtils.java
@@ -267,7 +267,7 @@ public final class ReflectionUtils {
         final List<Pair<Integer, Method>> lm = new ArrayList<>(candidates.length);
         for (final Method m: candidates) {
             final Class<?>[] expectedParameters = m.getParameterTypes();
-            final Class<?>[] actualArgClass;
+            final Class<?>[] actualArgClass; // NOPMD: false positive
             if (shouldPushContext(expectedParameters, argClass.length == 0 ? null : argClass[0])) {
                 /*
                  * Push "self" as implicit parameter
@@ -343,7 +343,7 @@ public final class ReflectionUtils {
             // We will repackage into an array of the expected length
             final Object[] newargs = new Object[expectedArgs.length];
             // repackage all the base args
-            final int start;
+            final int start; // NOPMD: false positive
             if (pushContext) {
                 newargs[0] = context;
                 start = 1;

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/util/ReflectionUtils.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/util/ReflectionUtils.java
@@ -21,6 +21,9 @@ import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
@@ -81,8 +84,10 @@ public final class ReflectionUtils {
     private ReflectionUtils() {
     }
 
-    private static boolean compatibleLength(final Method m, final Object[] args) {
-        final Class<?>[] paramTypes = m.getParameterTypes();
+    private static boolean compatibleLength(@Nonnull final Method m, @Nonnull final Object[] args) {
+        Objects.requireNonNull(args, "Argument list cannot be null. Tried to invoke: " + m);
+        final Class<?>[] paramTypes = Objects.requireNonNull(m, "Invoked method cannot be null.")
+            .getParameterTypes();
         final boolean requiresContext = paramTypes.length > 0
                 && ExecutionContext.class.isAssignableFrom(paramTypes[0]);
         /*
@@ -164,10 +169,10 @@ public final class ReflectionUtils {
      * @return the result of the method invocation
      */
     public static Object invokeFieldable(
-            final ExecutionContext context,
-            final Method toInvoke,
-            final Object target,
-            final Object[] args) {
+            @Nonnull final ExecutionContext context,
+            @Nonnull final Method toInvoke,
+            @Nullable final Object target,
+            @Nonnull final Object[] args) {
         if (!compatibleLength(toInvoke, args)) {
             throw new IllegalArgumentException("Number of parameters of " + toInvoke
                     + " does not match the provided array " + Arrays.toString(args));
@@ -192,7 +197,11 @@ public final class ReflectionUtils {
     }
 
     @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION", justification = "we need to intercept all runtime events")
-    private static Object invokeMethod(final ExecutionContext context, final Method method, final Object target, final Object[] args) {
+    private static Object invokeMethod(
+            @Nonnull final ExecutionContext context,
+            @Nonnull final Method method,
+            @Nullable final Object target,
+            @Nonnull final Object[] args) {
         final Object[] useArgs = repackageIfRequired(context, method, args);
         try {
             return method.invoke(target, useArgs);
@@ -336,9 +345,9 @@ public final class ReflectionUtils {
         }
     }
 
-    private static Object[] repackageIfRequired(final ExecutionContext context, final Method m, final Object[] args) {
+    private static Object[] repackageIfRequired(@Nonnull final ExecutionContext context, @Nonnull final Method m, @Nonnull final Object[] args) {
         final Class<?>[] expectedArgs = m.getParameterTypes();
-        final boolean pushContext = shouldPushContext(expectedArgs, args.length == 0 ? null : args[0].getClass());
+        final boolean pushContext = shouldPushContext(expectedArgs, args.length == 0 || args[0] == null ? null : args[0].getClass());
         if (m.isVarArgs() || pushContext) {
             // We will repackage into an array of the expected length
             final Object[] newargs = new Object[expectedArgs.length];

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/HashingCodePathFactory.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/HashingCodePathFactory.java
@@ -9,6 +9,7 @@ import org.protelis.vm.CodePathFactory;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hasher;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import gnu.trove.list.TIntList;
 import gnu.trove.stack.TIntStack;
 import java8.util.function.Supplier;
@@ -32,6 +33,7 @@ import java8.util.function.Supplier;
  * </pre>
  * 
  */
+@SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "False positive, checked by a test.")
 public class HashingCodePathFactory implements CodePathFactory {
 
     private static final long serialVersionUID = 1L;

--- a/protelis/protelis-interpreter/src/test/java/org/protelis/test/TestHashingCodePathFactory.java
+++ b/protelis/protelis-interpreter/src/test/java/org/protelis/test/TestHashingCodePathFactory.java
@@ -1,0 +1,33 @@
+package org.protelis.test;
+
+import static com.google.common.hash.Hashing.crc32;
+import static com.google.common.hash.Hashing.murmur3_128;
+import static com.google.common.hash.Hashing.sha256;
+import static com.google.common.hash.Hashing.sha384;
+import static com.google.common.hash.Hashing.sha512;
+import static com.google.common.hash.Hashing.sipHash24;
+import static org.apache.commons.lang3.SerializationUtils.deserialize;
+import static org.apache.commons.lang3.SerializationUtils.serialize;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.protelis.vm.impl.HashingCodePathFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.hash.HashFunction;
+
+/**
+ *
+ */
+public class TestHashingCodePathFactory {
+
+    /**
+     * Ensures serializability of {@link HashingCodePathFactory}.
+     */
+    @Test
+    public void testSerialization() {
+        for (HashFunction fun : ImmutableList.of(murmur3_128(), sha256(), sha384(), sha512(), crc32(), sipHash24())) {
+            assertNotNull(deserialize(serialize(new HashingCodePathFactory(fun))));
+        }
+    }
+}

--- a/protelis/protelis-lang/src/main/protelis/protelis/state/time.pt
+++ b/protelis/protelis-lang/src/main/protelis/protelis/state/time.pt
@@ -154,7 +154,7 @@ public def isFallingEdge(signal) {
         } else {
             [signal, false]
         }
-    }.get(1);
+    }.get(1)
 }
 
 /**
@@ -183,7 +183,7 @@ public def isRisingEdge(signal) {
         } else {
             [signal, false]
         }
-    }.get(1);
+    }.get(1)
 }
 
 /**

--- a/protelis/protelis-test/build.gradle.kts
+++ b/protelis/protelis-test/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
+    api(Libs.junit)
     api(project(":protelis-interpreter"))
     implementation(Libs.alchemist_interfaces) {
         exclude(module = "asm-debug-all")
@@ -6,6 +7,6 @@ dependencies {
     implementation(Libs.alchemist_loading) {
         exclude(module = "asm-debug-all")
     }
-    api(Libs.junit)
     implementation(Libs.commons_lang3)
+    implementation(Libs.classgraph)
 }

--- a/protelis/protelis-test/src/main/java/it/unibo/alchemist/loader/YamlLoader.java
+++ b/protelis/protelis-test/src/main/java/it/unibo/alchemist/loader/YamlLoader.java
@@ -45,7 +45,7 @@ import org.yaml.snakeyaml.Yaml;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 
-
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import it.unibo.alchemist.SupportedIncarnations;
 import it.unibo.alchemist.loader.displacements.Displacement;
 import it.unibo.alchemist.loader.export.Extractor;

--- a/protelis/protelis-test/src/main/java/org/protelis/test/ProgramTester.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/ProgramTester.java
@@ -23,6 +23,7 @@ import org.protelis.vm.ProtelisVM;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java8.util.Objects;
 import java8.util.function.Consumer;
 import java8.util.stream.IntStream;
@@ -173,12 +174,12 @@ public final class ProgramTester {
      * @param runs
      *            number of runs
      */
+    @SuppressFBWarnings(value = "OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE", justification="false positive")
     public static void runFile(final String file, final int runs) {
         final Object execResult = runProgram(Objects.requireNonNull(file, "File in test cannot be null"), runs);
         final String fileWithExt = file.endsWith(".pt") ? file : "/" + file + ".pt";
-        final InputStream is = Objects.requireNonNull(ProgramTester.class.getResourceAsStream(fileWithExt), 
-                "Unable to load resource: " + file + " (transformed in: " + fileWithExt + ')');
-        try {
+        try (InputStream is = Objects.requireNonNull(ProgramTester.class.getResourceAsStream(fileWithExt), 
+                "Unable to load resource: " + file + " (transformed in: " + fileWithExt + ')')) {
             final String test = IOUtils.toString(is, StandardCharsets.UTF_8);
             final Matcher extractor = EXTRACT_RESULT.matcher(test);
             if (extractor.find()) {

--- a/protelis/protelis-test/src/main/java/org/protelis/test/ProgramTester.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/ProgramTester.java
@@ -174,7 +174,6 @@ public final class ProgramTester {
      * @param runs
      *            number of runs
      */
-    @SuppressFBWarnings(value = "OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE", justification="false positive")
     public static void runFile(final String file, final int runs) {
         final Object execResult = runProgram(Objects.requireNonNull(file, "File in test cannot be null"), runs);
         final String fileWithExt = file.endsWith(".pt") ? file : "/" + file + ".pt";

--- a/protelis/protelis-test/src/main/java/org/protelis/test/ProgramTester.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/ProgramTester.java
@@ -23,6 +23,7 @@ import org.protelis.vm.ProtelisVM;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java8.util.Objects;
 import java8.util.function.Consumer;
 import java8.util.stream.IntStream;
 import java8.util.stream.IntStreams;
@@ -173,9 +174,10 @@ public final class ProgramTester {
      *            number of runs
      */
     public static void runFile(final String file, final int runs) {
-        final Object execResult = runProgram(file, runs);
+        final Object execResult = runProgram(Objects.requireNonNull(file, "File in test cannot be null"), runs);
         final String fileWithExt = file.endsWith(".pt") ? file : "/" + file + ".pt";
-        final InputStream is = ProgramTester.class.getResourceAsStream(fileWithExt);
+        final InputStream is = Objects.requireNonNull(ProgramTester.class.getResourceAsStream(fileWithExt), 
+                "Unable to load resource: " + file + " (transformed in: " + fileWithExt + ')');
         try {
             final String test = IOUtils.toString(is, StandardCharsets.UTF_8);
             final Matcher extractor = EXTRACT_RESULT.matcher(test);

--- a/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyContext.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyContext.java
@@ -18,15 +18,16 @@ import org.protelis.vm.impl.AbstractExecutionContext;
 import org.protelis.vm.impl.SimpleExecutionEnvironment;
 import org.protelis.vm.impl.SimpleNetworkManager;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java8.util.stream.IntStreams;
 
 /**
  * A **dummy** Protelis VM to be used for testing.
  *
  */
+@SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC_ANON")
 public final class DummyContext extends AbstractExecutionContext {
 
-    private final Random rng = new Random(0);
     private static final DeviceUID DUMMYUID = new DeviceUID() {
         private static final long serialVersionUID = 2306021805006825289L;
 
@@ -35,6 +36,7 @@ public final class DummyContext extends AbstractExecutionContext {
             return "DummyUID";
         };
     };
+    private final Random rng = new Random(0);
 
     /**
      *
@@ -48,11 +50,6 @@ public final class DummyContext extends AbstractExecutionContext {
      */
     public DummyContext(final NetworkManager networkManager) {
         super(new SimpleExecutionEnvironment(), networkManager);
-    }
-
-    @Override
-    public DeviceUID getDeviceUID() {
-        return DUMMYUID;
     }
 
     // ATTENTION: System.currentTimeMillis() is not reproducible
@@ -76,13 +73,32 @@ public final class DummyContext extends AbstractExecutionContext {
     }
 
     @Override
-    public double nextRandomDouble() {
-        return rng.nextDouble();
+    public DeviceUID getDeviceUID() {
+        return DUMMYUID;
     }
 
     @Override
     protected AbstractExecutionContext instance() {
         return new DummyContext();
+    }
+
+    /**
+     * Test utility.
+     * 
+     * @param entries
+     *            how many entries for the field
+     * @return a field with populated with numbers from 0 to 99
+     */
+    @SuppressWarnings("serial")
+    public Field makeTestField(final int entries) {
+        final Field res = DatatypeFactory.createField(entries);
+        IntStreams.range(0, entries).forEach(n -> res.addSample(new DeviceUID() { }, (double) n));
+        return res;
+    }
+
+    @Override
+    public double nextRandomDouble() {
+        return rng.nextDouble();
     }
 
     @Override
@@ -100,20 +116,6 @@ public final class DummyContext extends AbstractExecutionContext {
         IntStreams.range(0, 100).forEach(n -> res.addSample(new DeviceUID() {
             private static final long serialVersionUID = 1L;
         }, (double) n));
-        return res;
-    }
-
-    /**
-     * Test utility.
-     * 
-     * @param entries
-     *            how many entries for the field
-     * @return a field with populated with numbers from 0 to 99
-     */
-    @SuppressWarnings("serial")
-    public Field makeTestField(final int entries) {
-        final Field res = DatatypeFactory.createField(entries);
-        IntStreams.range(0, entries).forEach(n -> res.addSample(new DeviceUID() { }, (double) n));
         return res;
     }
 

--- a/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/RunProtelisProgram.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/RunProtelisProgram.java
@@ -56,7 +56,7 @@ public final class RunProtelisProgram extends SimpleMolecule implements Action<O
      *             if required classes can not be found
      */
     public RunProtelisProgram(final Environment<Object> env, final ProtelisNode n, final Reaction<Object> r,
-                    final RandomGenerator rand, final String prog) throws SecurityException {
+                    final RandomGenerator rand, final String prog) {
         this(env, n, r, rand, ProtelisLoader.parse(prog));
     }
 

--- a/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/RunProtelisProgram.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/RunProtelisProgram.java
@@ -56,7 +56,7 @@ public final class RunProtelisProgram extends SimpleMolecule implements Action<O
      *             if required classes can not be found
      */
     public RunProtelisProgram(final Environment<Object> env, final ProtelisNode n, final Reaction<Object> r,
-                    final RandomGenerator rand, final String prog) throws SecurityException, ClassNotFoundException {
+                    final RandomGenerator rand, final String prog) throws SecurityException {
         this(env, n, r, rand, ProtelisLoader.parse(prog));
     }
 

--- a/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/TestIncarnation.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/TestIncarnation.java
@@ -120,7 +120,7 @@ public final class TestIncarnation implements Incarnation<Object> {
             final ProtelisNode pNode = (ProtelisNode) node;
             try {
                 return new RunProtelisProgram(env, pNode, reaction, rand, param);
-            } catch (ClassNotFoundException | RuntimeException e) { // NOPMD: we want to catch any runtime exception
+            } catch (RuntimeException e) { // NOPMD: we want to catch any runtime exception
                 throw new IllegalArgumentException("Could not create the requested Protelis program: " + param, e);
             }
         }

--- a/protelis/protelis-test/src/main/java/org/protelis/test/matcher/TestEqual.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/matcher/TestEqual.java
@@ -35,12 +35,12 @@ public final class TestEqual implements BiConsumer<Map<String, Object>, List<Pai
                     try {
                         assertNotNull(singleNodeResult);
                         if (singleNodeResult instanceof Integer || singleNodeResult instanceof Double) {
-                            final Double tmp = singleNodeResult instanceof Integer ? ((Integer) singleNodeResult).doubleValue() : (double) singleNodeResult;
+                            final double tmp = singleNodeResult instanceof Integer ? ((Integer) singleNodeResult).doubleValue() : (double) singleNodeResult;
                             assertEquals(Double.parseDouble(pair.getRight()), tmp, InfrastructureTester.DELTA);
                         } else if (singleNodeResult instanceof Boolean) {
                             final String v = pair.getRight();
-                            final Boolean expected = Boolean.parseBoolean(v.equals("T") ? "true" : v.equals("F") ? "false" : pair.getRight());
-                            assertEquals(expected.booleanValue(), ((Boolean) singleNodeResult).booleanValue());
+                            final boolean expected = Boolean.parseBoolean(v.equals("T") ? "true" : v.equals("F") ? "false" : pair.getRight());
+                            assertEquals(expected, (Boolean) singleNodeResult);
                         } else {
                             assertEquals(pair.getRight(), singleNodeResult);
                         }

--- a/protelis/protelis-test/src/main/java/org/protelis/test/matcher/TestEqual.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/matcher/TestEqual.java
@@ -16,7 +16,7 @@ import java8.util.function.BiConsumer;
  */
 public final class TestEqual implements BiConsumer<Map<String, Object>, List<Pair<String, String>>> {
     private final ExceptionObserver obs;
-    private static final String ERROR_TEMPLATE = "\n --- Simulation result\n --- %s\n[N%s] expected: %s, found: %s";
+    private static final String ERROR_TEMPLATE = "%n --- Simulation result%n --- %s%n[N%s] expected: %s, found: %s";
     /**
      * @param obs
      *            exception observer
@@ -45,7 +45,8 @@ public final class TestEqual implements BiConsumer<Map<String, Object>, List<Pai
                             assertEquals(pair.getRight(), singleNodeResult);
                         }
                     } catch (Exception | AssertionError e) { // NOPMD
-                        obs.exceptionThrown(new IllegalStateException(String.format(ERROR_TEMPLATE, getMessage(simulationRes, expectedResult), pair.getLeft(), pair.getRight(), singleNodeResult)));
+                        obs.exceptionThrown(new IllegalStateException(String.format(ERROR_TEMPLATE,
+                                getMessage(simulationRes, expectedResult), pair.getLeft(), pair.getRight(), singleNodeResult)));
                         break;
                     }
                 }

--- a/protelis/protelis-test/src/test/java/org/protelis/test/TestJavaNull.java
+++ b/protelis/protelis-test/src/test/java/org/protelis/test/TestJavaNull.java
@@ -43,7 +43,7 @@ public final class TestJavaNull {
     /**
      * @return null
      */
-    public String returnsNull() {
+    public static String returnsNull() {
         return null;
     }
 

--- a/protelis/protelis-test/src/test/java/org/protelis/test/TestJavaNull.java
+++ b/protelis/protelis-test/src/test/java/org/protelis/test/TestJavaNull.java
@@ -22,7 +22,7 @@ public final class TestJavaNull {
             ResourceList programs = scanResult.getResourcesWithExtension("pt");
             ResourceList exceptions = programs.filter(it -> it.getPath().contains("error"));
             ResourceList regular = programs.filter(it -> !exceptions.contains(it));
-            regular.forEach(it -> ProgramTester.runFile('/' + it.getPath(), 1));
+            regular.forEach(it -> ProgramTester.runFile('/' + it.getPath()));
             exceptions.forEach(it -> ProgramTester.runExpectingErrors('/' + it.getPath(), Throwable.class));
         }
     }

--- a/protelis/protelis-test/src/test/java/org/protelis/test/TestJavaNull.java
+++ b/protelis/protelis-test/src/test/java/org/protelis/test/TestJavaNull.java
@@ -1,0 +1,57 @@
+package org.protelis.test;
+
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ResourceList;
+import io.github.classgraph.ScanResult;
+
+/**
+ * Tests for Option and null.
+ */
+public final class TestJavaNull {
+
+    /**
+     * Runs all tests in protelis/option.
+     */
+    @Test
+    public void testProtelisOption() {
+        try (ScanResult scanResult = new ClassGraph().whitelistPathsNonRecursive("protelis/option").scan()) {
+            ResourceList programs = scanResult.getResourcesWithExtension("pt");
+            ResourceList exceptions = programs.filter(it -> it.getPath().contains("error"));
+            ResourceList regular = programs.filter(it -> !exceptions.contains(it));
+            regular.forEach(it -> ProgramTester.runFile('/' + it.getPath(), 1));
+            exceptions.forEach(it -> ProgramTester.runExpectingErrors('/' + it.getPath(), Throwable.class));
+        }
+    }
+
+    /**
+     * @param o must be null
+     */
+    public static void expectsNull(final Object o) {
+        assertNull(o);
+    }
+
+    /**
+     * 
+     */
+    public static void returnsVoid() {
+    }
+
+    /**
+     * @return null
+     */
+    public String returnsNull() {
+        return null;
+    }
+
+    /**
+     * @return with 50% probability null, with 50% probability the "notNull" String.
+     */
+    public static String mayReturnNull() {
+        return Math.random() > 0.5 ? null : "notNull";
+    }
+
+}

--- a/protelis/protelis-test/src/test/java/org/protelis/test/TestJavaNull.java
+++ b/protelis/protelis-test/src/test/java/org/protelis/test/TestJavaNull.java
@@ -19,9 +19,9 @@ public final class TestJavaNull {
     @Test
     public void testProtelisOption() {
         try (ScanResult scanResult = new ClassGraph().whitelistPathsNonRecursive("protelis/option").scan()) {
-            ResourceList programs = scanResult.getResourcesWithExtension("pt");
-            ResourceList exceptions = programs.filter(it -> it.getPath().contains("error"));
-            ResourceList regular = programs.filter(it -> !exceptions.contains(it));
+            final ResourceList programs = scanResult.getResourcesWithExtension("pt");
+            final ResourceList exceptions = programs.filter(it -> it.getPath().contains("error"));
+            final ResourceList regular = programs.filter(it -> !exceptions.contains(it));
             regular.forEach(it -> ProgramTester.runFile('/' + it.getPath()));
             exceptions.forEach(it -> ProgramTester.runExpectingErrors('/' + it.getPath(), Throwable.class));
         }

--- a/protelis/protelis-test/src/test/java/org/protelis/test/TestJavaNull.java
+++ b/protelis/protelis-test/src/test/java/org/protelis/test/TestJavaNull.java
@@ -50,7 +50,7 @@ public final class TestJavaNull {
     /**
      * @return with 50% probability null, with 50% probability the "notNull" String.
      */
-    public static String mayReturnNull() {
+    public static String maybeNull() {
         return Math.random() > 0.5 ? null : "notNull";
     }
 

--- a/protelis/protelis-test/src/test/java/org/protelis/test/TestLanguage.java
+++ b/protelis/protelis-test/src/test/java/org/protelis/test/TestLanguage.java
@@ -847,7 +847,7 @@ public class TestLanguage {
         Assert.assertEquals(false, ProgramTester.runProgram("[1, 2, -1] <= [1, 2]", 1));
         Assert.assertEquals(false, ProgramTester.runProgram("[1, 2, -1, 0, 0] <= [1, 2, -1]", 1));
         // comparison involving infinity
-        final String prefix = "import java.lang.Double.POSITIVE_INFINITY let Infinity = POSITIVE_INFINITY; ";
+        final String prefix = "import java.lang.Double.POSITIVE_INFINITY let Infinity = POSITIVE_INFINITY; "; // NOPMD
         Assert.assertEquals(true, ProgramTester.runProgram(prefix + "[Infinity] == [Infinity]", 1));
         Assert.assertEquals(true, ProgramTester.runProgram(prefix + "[Infinity, 1] < [Infinity, 2]", 1));
         Assert.assertEquals(true, ProgramTester.runProgram(prefix + "[1, Infinity] < [2, 0]", 1));

--- a/protelis/protelis-test/src/test/java/org/protelis/test/TestShareSharedValues.java
+++ b/protelis/protelis-test/src/test/java/org/protelis/test/TestShareSharedValues.java
@@ -21,6 +21,8 @@ import org.protelis.vm.CodePath;
 import org.protelis.vm.NetworkManager;
 import org.protelis.vm.ProtelisVM;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Main collection of tests for the Protelis language and VM.
  */
@@ -34,6 +36,7 @@ public class TestShareSharedValues {
      * where the shared values are those computed within the nbr call).
      */
     @Test
+    @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC_ANON")
     public void testLatestHasBeenShared() {
         final MutableInt cycle = new MutableInt(0);
         final ProtelisVM vm = new ProtelisVM(ProtelisLoader.parse(PROGRAM), new DummyContext(new NetworkManager() {

--- a/protelis/protelis-test/src/test/resources/protelis/option/optionhigherorder.pt
+++ b/protelis/protelis-test/src/test/resources/protelis/option/optionhigherorder.pt
@@ -1,0 +1,13 @@
+/*
+ * EXPECTED_RESULT: 7
+ */
+module protelis:option:sideeffects
+import org.protelis.test.TestJavaNull.maybeNull
+import org.protelis.lang.datatype.Option.none
+import org.protelis.lang.datatype.Option.fromNullable
+
+fromNullable(maybeNull())
+    .map(it -> { it.length() })
+    .filter(it -> { it > 0 })
+    .filterNot(it -> { it > 10 })
+    .orElseGet(() -> { "notNull".length() })

--- a/protelis/protelis-test/src/test/resources/protelis/option/passnull.pt
+++ b/protelis/protelis-test/src/test/resources/protelis/option/passnull.pt
@@ -1,0 +1,8 @@
+/*
+ * EXPECTED_RESULT: true
+ */
+import org.protelis.test.TestJavaNull.expectsNull
+import org.protelis.lang.datatype.Option.none
+import org.protelis.lang.datatype.Option.fromNullable
+
+fromNullable(expectsNull(none())).isEmpty()

--- a/protelis/protelis-test/src/test/resources/protelis/option/passnullthorugh.pt
+++ b/protelis/protelis-test/src/test/resources/protelis/option/passnullthorugh.pt
@@ -1,0 +1,10 @@
+/*
+ * EXPECTED_RESULT: true
+ */
+module protelis:option:passnullthrough
+import org.protelis.test.TestJavaNull.returnsNull
+import org.protelis.test.TestJavaNull.expectsNull
+import org.protelis.lang.datatype.Option.none
+import org.protelis.lang.datatype.Option.fromNullable
+
+fromNullable(expectsNull(expectsNull(returnsNull()))).isEmpty()

--- a/protelis/protelis-test/src/test/resources/protelis/option/sideeffects.pt
+++ b/protelis/protelis-test/src/test/resources/protelis/option/sideeffects.pt
@@ -1,0 +1,15 @@
+/*
+ * EXPECTED_RESULT: true
+ */
+module protelis:option:sideeffects
+import org.protelis.test.TestJavaNull.returnsVoid
+import org.protelis.test.TestJavaNull.expectsNull
+import org.protelis.lang.datatype.Option.none
+import org.protelis.lang.datatype.Option.fromNullable
+
+returnsVoid();
+returnsVoid();
+if (true) {
+    returnsVoid()
+};
+fromNullable(returnsVoid()).isEmpty()


### PR DESCRIPTION
* Introduces the new Option class, allowing for safely dealing with Java nulls (in and out)
* Hardens Protelis against null values, by adopting a fail-fast policy
* Other minor improvements