### PR TITLE
(Quick) Fix to Protelis2Doc plugin application

### DIFF
--- a/protelis/build.gradle.kts
+++ b/protelis/build.gradle.kts
@@ -14,12 +14,12 @@ plugins {
     pmd
     checkstyle
     id("org.jlleitschuh.gradle.ktlint") version Versions.org_jlleitschuh_gradle_ktlint_gradle_plugin
-    id("org.protelis.protelisdoc") version "0.1.1-dev08+b8184c8"
     signing
     `maven-publish`
     id("org.danilopianini.publish-on-central") version Versions.org_danilopianini_publish_on_central_gradle_plugin
     id("com.jfrog.bintray") version Versions.com_jfrog_bintray_gradle_plugin
     id("com.gradle.build-scan") version Versions.com_gradle_build_scan_gradle_plugin
+    id("org.jetbrains.kotlin.jvm") version "1.3.31"
 }
 
 apply(plugin = "com.gradle.build-scan")
@@ -39,7 +39,6 @@ allprojects {
     apply(plugin = "pmd")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
     apply(plugin = "org.jetbrains.kotlin.jvm")
-//    apply(plugin = "org.protelis.protelisdoc")
     apply(plugin = "project-report")
     apply(plugin = "build-dashboard")
     apply(plugin = "signing")

--- a/protelis/protelis-lang/build.gradle.kts
+++ b/protelis/protelis-lang/build.gradle.kts
@@ -1,6 +1,11 @@
+plugins {
+    id("org.protelis.protelisdoc") version "0.1.1-dev0f+1c1a147"
+}
+
 dependencies {
     implementation(project(":protelis-interpreter"))
     testImplementation(project(":protelis-test"))
+    implementation(kotlin("stdlib"))
 }
 
 sourceSets {


### PR DESCRIPTION
- Application to `protelis-lang` only
- Note: `kotlin-jvm` plugin is applied to global build; if I applied it only to `protelis-lang` I would get the following error

```
* What went wrong:
An exception occurred applying plugin request [id: 'org.jetbrains.kotlin.jvm', version: '1.3.31']
> Failed to apply plugin [id 'org.jetbrains.kotlin.jvm']
   > Cannot change attributes of configuration ':protelis-lang:compile' after it has been resolved
```