### PR TITLE
Enforce "self." consistency across restricted domains

### DIFF
--- a/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyContext.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyContext.java
@@ -26,7 +26,7 @@ import java8.util.stream.IntStreams;
  *
  */
 @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC_ANON")
-public final class DummyContext extends AbstractExecutionContext {
+public final class DummyContext extends AbstractExecutionContext<DummyContext> {
 
     private static final DeviceUID DUMMYUID = new DeviceUID() {
         private static final long serialVersionUID = 2306021805006825289L;
@@ -78,7 +78,7 @@ public final class DummyContext extends AbstractExecutionContext {
     }
 
     @Override
-    protected AbstractExecutionContext instance() {
+    protected DummyContext instance() {
         return new DummyContext();
     }
 

--- a/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyDevice.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyDevice.java
@@ -20,7 +20,7 @@ import it.unibo.alchemist.model.interfaces.Reaction;
  * A simple implementation of a Protelis-based device, encapsulating a
  * ProtelisVM and a network interface.
  */
-public final class DummyDevice extends AbstractExecutionContext
+public final class DummyDevice extends AbstractExecutionContext<DummyDevice>
                 implements SpatiallyEmbeddedDevice, LocalizedDevice, TimeAwareDevice {
     private final RandomGenerator r;
     private final ProtelisNode node;
@@ -77,7 +77,7 @@ public final class DummyDevice extends AbstractExecutionContext
     }
 
     @Override
-    protected AbstractExecutionContext instance() {
+    protected DummyDevice instance() {
         return new DummyDevice(env, node, react, r, netmgr);
     }
 


### PR DESCRIPTION
In this example I enforce a coherent implementation of "self" via curiously recurring invariant generic pattern.
This guarantees compile-time checks on the restricted contexts (unless compliance gets forced via erasure, by either raw types or wild casting).

This change is likely to break compatibility of "child" implementation of executioncontexts, as the one proposed in #171. It would make it a bit harder to implement badly a concrete `ExecutionContext`, thereby reducing [viscosity](https://en.wikipedia.org/wiki/Viscosity_(programming)).