### PR TITLE
Add tests for foldMin, foldMax, foldUnion

### DIFF
--- a/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyContext.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyContext.java
@@ -13,6 +13,7 @@ import java.util.Random;
 import org.protelis.lang.datatype.DatatypeFactory;
 import org.protelis.lang.datatype.DeviceUID;
 import org.protelis.lang.datatype.Field;
+import org.protelis.lang.datatype.Tuple;
 import org.protelis.vm.ExecutionContext;
 import org.protelis.vm.NetworkManager;
 import org.protelis.vm.impl.AbstractExecutionContext;
@@ -98,6 +99,22 @@ public final class DummyContext extends AbstractExecutionContext<DummyContext> {
         return res.build(getDeviceUID(), 0.0);
     }
 
+    /**
+     * Test utility.
+     * 
+     * @param entries
+     *            how many entries for the field
+     * @return a field with populated with tuples of numbers from 0 to 99
+     */
+    @SuppressWarnings("serial")
+    public Field<Tuple> makeTupleTestField(final int entries) {
+        final Field.Builder<Tuple> res = DatatypeFactory.createFieldBuilder();
+        IntStreams.range(1, entries)
+            .mapToDouble(it -> it)
+            .forEach(n -> res.add(new DeviceUID() { }, DatatypeFactory.createTuple(n)));
+        return res.build(getDeviceUID(), DatatypeFactory.createTuple(0));
+    }
+    
     @Override
     public double nextRandomDouble() {
         return rng.nextDouble();

--- a/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyContext.java
+++ b/protelis/protelis-test/src/main/java/org/protelis/test/infrastructure/DummyContext.java
@@ -114,7 +114,7 @@ public final class DummyContext extends AbstractExecutionContext<DummyContext> {
             .forEach(n -> res.add(new DeviceUID() { }, DatatypeFactory.createTuple(n)));
         return res.build(getDeviceUID(), DatatypeFactory.createTuple(0));
     }
-    
+
     @Override
     public double nextRandomDouble() {
         return rng.nextDouble();

--- a/protelis/protelis-test/src/test/resources/maxhood02.pt
+++ b/protelis/protelis-test/src/test/resources/maxhood02.pt
@@ -1,3 +1,3 @@
 // EXPECTED_RESULT: import java.lang.Double.POSITIVE_INFINITY let Infinity = POSITIVE_INFINITY; [-Infinity, -Infinity, -Infinity]
 
-maxHood([nbr(1), -nbr(1), 1])
+foldMax([NEGATIVE_INFINITY, NEGATIVE_INFINITY, NEGATIVE_INFINITY], [nbr(1), -nbr(1), 1])

--- a/protelis/protelis-test/src/test/resources/minhood01.pt
+++ b/protelis/protelis-test/src/test/resources/minhood01.pt
@@ -1,3 +1,2 @@
 // EXPECTED_RESULT: import java.lang.Double.POSITIVE_INFINITY let Infinity = POSITIVE_INFINITY; [Infinity, Infinity]
-
-minHood(nbr([0, 0]))
+foldMin([POSITIVE_INFINITY, POSITIVE_INFINITY], nbr([0, 0]))

--- a/protelis/protelis-test/src/test/resources/unionhood01.pt
+++ b/protelis/protelis-test/src/test/resources/unionhood01.pt
@@ -1,2 +1,2 @@
 // EXPECTED_RESULT: [1]
-unionHood(self.makeTestField(2))
+foldUnion([], self.makeTupleTestField(2))

--- a/protelis/protelis-test/src/test/resources/unionhood02.pt
+++ b/protelis/protelis-test/src/test/resources/unionhood02.pt
@@ -1,2 +1,2 @@
 // EXPECTED_RESULT: [] 
-unionHood(nbr(1))
+foldUnion([], nbr(1))


### PR DESCRIPTION
While debugging a problem with folding in our use of Protelis 13, I discovered that foldUnion wasn't being tested correctly.  I also added tests for foldMin and foldMax.