### PR TITLE
Introduce Unit

### DIFF
--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/Unit.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/Unit.java
@@ -1,0 +1,12 @@
+package org.protelis.lang.datatype;
+
+/**
+ * Special type holding a single possible value. See https://en.wikipedia.org/wiki/Unit_type
+ *
+ */
+public enum Unit {
+    /**
+     * Unit type of Protelis. https://en.wikipedia.org/wiki/Unit_type
+     */
+    UNIT
+}

--- a/protelis/protelis-test/src/test/java/org/protelis/test/TestJavaNull.java
+++ b/protelis/protelis-test/src/test/java/org/protelis/test/TestJavaNull.java
@@ -29,9 +29,11 @@ public final class TestJavaNull {
 
     /**
      * @param o must be null
+     * @return null
      */
-    public static void expectsNull(final Object o) {
+    public static Object expectsNull(final Object o) {
         assertNull(o);
+        return o;
     }
 
     /**

--- a/protelis/protelis-test/src/test/java/org/protelis/test/TestLanguage.java
+++ b/protelis/protelis-test/src/test/java/org/protelis/test/TestLanguage.java
@@ -923,4 +923,12 @@ public class TestLanguage {
         runFile("/unionhood02.pt");
     }
 
+    /**
+     * Test calling a void method.
+     */
+    @Test
+    public void testUnit01() {
+        runFile("/unit01.pt");
+    }
+
 }

--- a/protelis/protelis-test/src/test/java/org/protelis/test/TestVoid.java
+++ b/protelis/protelis-test/src/test/java/org/protelis/test/TestVoid.java
@@ -1,0 +1,16 @@
+package org.protelis.test;
+
+/**
+ * Support class with void methods.
+ */
+public final class TestVoid {
+
+    private TestVoid() {
+    }
+
+    /**
+     * @param args unused
+     */
+    public static void main(final String... args) { }
+
+}

--- a/protelis/protelis-test/src/test/resources/protelis/option/sideeffects.pt
+++ b/protelis/protelis-test/src/test/resources/protelis/option/sideeffects.pt
@@ -1,5 +1,5 @@
 /*
- * EXPECTED_RESULT: true
+ * EXPECTED_RESULT: false
  */
 module protelis:option:sideeffects
 import org.protelis.test.TestJavaNull.returnsVoid

--- a/protelis/protelis-test/src/test/resources/unit01.pt
+++ b/protelis/protelis-test/src/test/resources/unit01.pt
@@ -1,0 +1,8 @@
+// EXPECTED_RESULT: import org.protelis.test.TestVoid.main main()
+module unit01
+import org.protelis.test.TestVoid.main
+import java.util.Collections.sort
+import java.util.Collections.emptyList
+
+main() // Should return Unit
+sort(emptyList()) // Again, unit


### PR DESCRIPTION
Reproduces #271 in a test, and fixes #275 

Only non-retrocompatible change:
`fromNullable(methodReturningVoid()).isEmpty()` now returns false (it's an optional which is `Present(Unit)`).