### PR TITLE
Fix corner case with field construction

### DIFF
--- a/protelis/config/checkstyle/checkstyle.xml
+++ b/protelis/config/checkstyle/checkstyle.xml
@@ -12,155 +12,161 @@
           "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
-    <!-- If you set the basedir property below, then all reported file names 
-        will be relative to the specified directory. See http://checkstyle.sourceforge.net/5.x/config.html#Checker 
-        <property name="basedir" value="${basedir}"/> -->
+	<!-- If you set the basedir property below, then all reported file names 
+		will be relative to the specified directory. See http://checkstyle.sourceforge.net/5.x/config.html#Checker 
+		<property name="basedir" value="${basedir}"/> -->
 
-    <property name="fileExtensions" value="java, properties, xml" />
+	<property name="fileExtensions" value="java, properties, xml" />
 
-    <module name="SuppressionFilter">
-        <property name="file" value="${config_loc}/suppressions.xml" />
-        <property name="optional" value="false" />
-    </module>
+	<module name="SuppressionFilter">
+		<property name="file" value="${config_loc}/suppressions.xml" />
+		<property name="optional" value="false" />
+	</module>
 
-    <!-- Checks whether files end with a new line. -->
-    <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
-    <module name="NewlineAtEndOfFile">
-        <property name="lineSeparator" value="lf" />
-    </module>
+	<!-- Checks whether files end with a new line. -->
+	<!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
+	<module name="NewlineAtEndOfFile">
+		<property name="lineSeparator" value="lf" />
+	</module>
 
-    <property name="severity" value="error" />
+	<property name="severity" value="error" />
 
-    <!-- Checks that property files contain the same keys. -->
-    <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
-    <module name="Translation" />
+	<!-- Checks that property files contain the same keys. -->
+	<!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
+	<module name="Translation" />
 
-    <!-- Checks for Size Violations. -->
-    <!-- See http://checkstyle.sf.net/config_sizes.html -->
-    <module name="FileLength" />
+	<!-- Checks for Size Violations. -->
+	<!-- See http://checkstyle.sf.net/config_sizes.html -->
+	<module name="FileLength" />
 
-    <!-- Checks for whitespace -->
-    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
-    <module name="FileTabCharacter" />
+	<!-- Checks for whitespace -->
+	<!-- See http://checkstyle.sf.net/config_whitespace.html -->
+	<module name="FileTabCharacter" />
 
-    <!-- Miscellaneous other checks. -->
-    <!-- See http://checkstyle.sf.net/config_misc.html -->
-    <module name="RegexpSingleline">
-        <property name="format" value="\s{2,}$" />
-        <property name="minimum" value="0" />
-        <property name="maximum" value="0" />
-        <property name="message" value="Line has trailing spaces." />
-    </module>
-    <module name="RegexpSingleline">
-        <property name="severity" value="warning" />
-        <property name="format" value="@author" />
-        <property name="fileExtensions" value="java,xtend,scala,kt" />
-        <property name="message"
-            value="Do not use @author. Changes and authors are tracked by the content manager." />
-    </module>
+	<!-- Miscellaneous other checks. -->
+	<!-- See http://checkstyle.sf.net/config_misc.html -->
+	<module name="RegexpSingleline">
+		<property name="format" value="\s{2,}$" />
+		<property name="minimum" value="0" />
+		<property name="maximum" value="0" />
+		<property name="message" value="Line has trailing spaces." />
+	</module>
+	<module name="RegexpMultiline">
+		<property name="severity" value="error" />
+		<property name="fileExtensions" value="java,xtend,scala,kt,xml,groovy,yaml,yml" />
+		<property name="format" value="(?s:(\r\n|\r).*)"/>
+		<property name="message" value="CRLF and CR line endings are prohibited, but this file uses them."/>
+	</module>
+	<module name="RegexpSingleline">
+		<property name="severity" value="warning" />
+		<property name="format" value="@author" />
+		<property name="fileExtensions" value="java,xtend,scala,kt" />
+		<property name="message"
+			value="Do not use @author. Changes and authors are tracked by the content manager." />
+	</module>
 
-    <module name="TreeWalker">
-        <module name="SuppressionCommentFilter">
-            <property name="offCommentFormat" value="CHECKSTYLE: ([\w\|]+) OFF" />
-            <property name="onCommentFormat" value="CHECKSTYLE: ([\w\|]+) ON" />
-            <property name="checkFormat" value="$1" />
-        </module>
-        <!-- Checks for Javadoc comments. -->
-        <!-- See http://checkstyle.sf.net/config_javadoc.html -->
-        <module name="JavadocMethod">
-            <property name="scope" value="protected" />
-        </module>
-        <module name="JavadocType">
-            <property name="severity" value="error" />
-            <property name="scope" value="protected" />
-        </module>
-        <module name="JavadocVariable">
-            <property name="scope" value="protected" />
-        </module>
-        <module name="JavadocStyle" />
+	<module name="TreeWalker">
+		<module name="SuppressionCommentFilter">
+			<property name="offCommentFormat" value="CHECKSTYLE: ([\w\|]+) OFF" />
+			<property name="onCommentFormat" value="CHECKSTYLE: ([\w\|]+) ON" />
+			<property name="checkFormat" value="$1" />
+		</module>
+		<!-- Checks for Javadoc comments. -->
+		<!-- See http://checkstyle.sf.net/config_javadoc.html -->
+		<module name="JavadocMethod">
+			<property name="scope" value="protected" />
+		</module>
+		<module name="JavadocType">
+			<property name="severity" value="error" />
+			<property name="scope" value="protected" />
+		</module>
+		<module name="JavadocVariable">
+			<property name="scope" value="protected" />
+		</module>
+		<module name="JavadocStyle" />
 
-        <!-- Checks for Naming Conventions. -->
-        <!-- See http://checkstyle.sf.net/config_naming.html -->
-        <module name="ConstantName" />
-        <module name="LocalFinalVariableName" />
-        <module name="LocalVariableName" />
-        <module name="MemberName" />
-        <module name="MethodName" />
-        <module name="PackageName" />
-        <module name="ParameterName" />
-        <module name="StaticVariableName" />
-        <module name="TypeName" />
+		<!-- Checks for Naming Conventions. -->
+		<!-- See http://checkstyle.sf.net/config_naming.html -->
+		<module name="ConstantName" />
+		<module name="LocalFinalVariableName" />
+		<module name="LocalVariableName" />
+		<module name="MemberName" />
+		<module name="MethodName" />
+		<module name="PackageName" />
+		<module name="ParameterName" />
+		<module name="StaticVariableName" />
+		<module name="TypeName" />
 
-        <!-- Checks for imports -->
-        <!-- See http://checkstyle.sf.net/config_import.html -->
-        <module name="AvoidStarImport" />
-        <module name="IllegalImport" /> <!-- defaults to sun.* packages -->
-        <module name="RedundantImport" />
-        <module name="UnusedImports">
-            <property name="processJavadoc" value="false" />
-        </module>
+		<!-- Checks for imports -->
+		<!-- See http://checkstyle.sf.net/config_import.html -->
+		<module name="AvoidStarImport" />
+		<module name="IllegalImport" /> <!-- defaults to sun.* packages -->
+		<module name="RedundantImport" />
+		<module name="UnusedImports">
+			<property name="processJavadoc" value="false" />
+		</module>
 
-        <!-- Checks for whitespace -->
-        <!-- See http://checkstyle.sf.net/config_whitespace.html -->
-        <module name="EmptyForIteratorPad" />
-        <module name="GenericWhitespace" />
-        <module name="MethodParamPad" />
-        <module name="NoWhitespaceAfter">
-            <property name="tokens"
-                value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS" />
-        </module>
-        <module name="NoWhitespaceBefore" />
-        <module name="OperatorWrap" />
-        <module name="ParenPad" />
-        <module name="TypecastParenPad" />
-        <module name="WhitespaceAfter" />
-        <module name="WhitespaceAround" />
+		<!-- Checks for whitespace -->
+		<!-- See http://checkstyle.sf.net/config_whitespace.html -->
+		<module name="EmptyForIteratorPad" />
+		<module name="GenericWhitespace" />
+		<module name="MethodParamPad" />
+		<module name="NoWhitespaceAfter">
+			<property name="tokens"
+				value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS" />
+		</module>
+		<module name="NoWhitespaceBefore" />
+		<module name="OperatorWrap" />
+		<module name="ParenPad" />
+		<module name="TypecastParenPad" />
+		<module name="WhitespaceAfter" />
+		<module name="WhitespaceAround" />
 
-        <!-- Modifier Checks -->
-        <!-- See http://checkstyle.sf.net/config_modifiers.html -->
-        <module name="ModifierOrder" />
-        <module name="RedundantModifier" />
+		<!-- Modifier Checks -->
+		<!-- See http://checkstyle.sf.net/config_modifiers.html -->
+		<module name="ModifierOrder" />
+		<module name="RedundantModifier" />
 
-        <!-- Checks for blocks. You know, those {}'s -->
-        <!-- See http://checkstyle.sf.net/config_blocks.html -->
-        <module name="AvoidNestedBlocks" />
-        <module name="EmptyBlock" />
-        <module name="LeftCurly" />
-        <module name="NeedBraces" />
-        <module name="RightCurly" />
+		<!-- Checks for blocks. You know, those {}'s -->
+		<!-- See http://checkstyle.sf.net/config_blocks.html -->
+		<module name="AvoidNestedBlocks" />
+		<module name="EmptyBlock" />
+		<module name="LeftCurly" />
+		<module name="NeedBraces" />
+		<module name="RightCurly" />
 
-        <!-- Checks for common coding problems -->
-        <!-- See http://checkstyle.sf.net/config_coding.html -->
-        <module name="EmptyStatement" />
-        <module name="EqualsHashCode" />
-        <module name="IllegalInstantiation" />
-        <module name="InnerAssignment" />
-        <module name="MagicNumber">
-            <property name="ignoreNumbers"
-                value="-0.5, -1, 0, 0.5, 1, 2, 3, 4, 8, 10, 16, 32, 64, 90, 100, 180, 360, 1000" />
-        </module>
-        <module name="MissingSwitchDefault" />
-        <module name="SimplifyBooleanExpression" />
-        <module name="SimplifyBooleanReturn" />
+		<!-- Checks for common coding problems -->
+		<!-- See http://checkstyle.sf.net/config_coding.html -->
+		<module name="EmptyStatement" />
+		<module name="EqualsHashCode" />
+		<module name="IllegalInstantiation" />
+		<module name="InnerAssignment" />
+		<module name="MagicNumber">
+			<property name="ignoreNumbers"
+				value="-0.5, -1, 0, 0.5, 1, 2, 3, 4, 8, 10, 16, 32, 64, 90, 100, 180, 360, 1000" />
+		</module>
+		<module name="MissingSwitchDefault" />
+		<module name="SimplifyBooleanExpression" />
+		<module name="SimplifyBooleanReturn" />
 
-        <!-- Checks for class design -->
-        <!-- See http://checkstyle.sf.net/config_design.html -->
-        <module name="DesignForExtension">
-        </module>
-        <module name="FinalClass">
+		<!-- Checks for class design -->
+		<!-- See http://checkstyle.sf.net/config_design.html -->
+		<module name="DesignForExtension">
+		</module>
+		<module name="FinalClass">
             <property name="severity" value="warning" />
-        </module>
-        <module name="HideUtilityClassConstructor" />
-        <module name="InterfaceIsType" />
-        <module name="VisibilityModifier" />
+		</module>
+		<module name="HideUtilityClassConstructor" />
+		<module name="InterfaceIsType" />
+		<module name="VisibilityModifier" />
 
-        <!-- Miscellaneous other checks. -->
-        <!-- See http://checkstyle.sf.net/config_misc.html -->
-        <module name="ArrayTypeStyle" />
-        <module name="FinalParameters" />
-        <module name="TodoComment">
+		<!-- Miscellaneous other checks. -->
+		<!-- See http://checkstyle.sf.net/config_misc.html -->
+		<module name="ArrayTypeStyle" />
+		<module name="FinalParameters" />
+		<module name="TodoComment">
             <property name="severity" value="info" />
         </module>
-        <module name="UpperEll" />
-    </module>
+		<module name="UpperEll" />
+	</module>
 </module>

--- a/protelis/config/checkstyle/suppressions.xml
+++ b/protelis/config/checkstyle/suppressions.xml
@@ -16,8 +16,8 @@
 	<suppress files="[/\\]target[/\\]" checks=".*"/>
 	<suppress files=".+\.(?:jar|zip|war|class|tar|bin)$" checks=".*"/>
 	<suppress files=".*[\\/]xtend-gen[\\/].*" checks=".*"/>
-	<suppress files=".*[\\/]src/antlr[\\/].*" checks=".*"/>
+	<suppress files=".*[\\/]src[\\/]antlr[\\/].*" checks=".*"/>
 	<suppress files=".*[\\/]generated-.*[\\/].*" checks=".*"/>
-	<suppress files=".*[\\/]expressions/parser[\\/].*" checks=".*"/>
+	<suppress files=".*[\\/]expressions[\\/]parser[\\/].*" checks=".*"/>
 	<suppress files=".*[\\/]biochemistrydsl[\\/].*" checks=".*"/>
 </suppressions>

--- a/protelis/config/pmd/pmd.xml
+++ b/protelis/config/pmd/pmd.xml
@@ -1,109 +1,116 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (C) 2010-2019, Danilo Pianini and contributors listed in the main project's alchemist/build.gradle file.
+  ~ Copyright (C) 2010-2019, Danilo Pianini and contributors listed in the main project's protelis/build.gradle.kts file.
   ~
-  ~ This file is part of Alchemist, and is distributed under the terms of the
+  ~ This file is part of Protelis, and is distributed under the terms of the
   ~ GNU General Public License, with a linking exception,
   ~ as described in the file LICENSE in the Alchemist distribution's top directory.
   -->
 
 <ruleset name="Ruleset by Danilo Pianini"
-    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
-    <description>Rules selected by Danilo Pianini</description>
-    <rule ref="category/java/bestpractices.xml">
-        <exclude name="AccessorClassGeneration" />
-        <exclude name="AccessorMethodGeneration" />
-        <exclude name="ConstantsInInterface" />
-        <exclude name="GuardLogStatement" />
-        <exclude name="JUnitAssertionsShouldIncludeMessage" />
-        <exclude name="JUnitTestContainsTooManyAsserts" />
-        <exclude name="JUnitTestsShouldIncludeAssert" />
-        <exclude name="OneDeclarationPerLine" />
-        <exclude name="PositionLiteralsFirstInCaseInsensitiveComparisons" />
-        <exclude name="PositionLiteralsFirstInComparisons" />
-        <exclude name="UseVarargs" />
-    </rule>
-    <rule ref="category/java/codestyle.xml">
-        <exclude name="AbstractNaming" />
-        <exclude name="AtLeastOneConstructor" />
-        <exclude name="AvoidFinalLocalVariable" />
-        <exclude name="AvoidPrefixingMethodParameters" />
-        <exclude name="AvoidUsingNativeCode" />
-        <exclude name="CallSuperInConstructor" />
-        <exclude name="ConfusingTernary" />
-        <exclude name="EmptyMethodInAbstractClassShouldBeAbstract" />
-        <exclude name="LongVariable" />
-        <exclude name="MDBAndSessionBeanNamingConvention" />
-        <exclude name="OnlyOneReturn" />
-        <exclude name="ShortClassName" />
-        <exclude name="ShortMethodName" />
-        <exclude name="ShortVariable" />
-        <exclude name="TooManyStaticImports" />
-    </rule>
-    <rule ref="category/java/codestyle.xml/ClassNamingConventions">
-        <properties>
-            <property name="utilityClassPattern" value="[A-Z][a-zA-Z0-9]+" />
-        </properties>
-    </rule>
-    <rule ref="category/java/design.xml">
-        <exclude name="AbstractClassWithoutAnyMethod" />
-        <exclude name="AvoidDeeplyNestedIfStmts" />
-        <exclude name="CouplingBetweenObjects" />
-        <exclude name="CyclomaticComplexity" />
-        <exclude name="DataClass" />
-        <exclude name="ExcessiveClassLength" />
-        <exclude name="ExcessiveImports" />
-        <exclude name="ExcessiveMethodLength" />
-        <exclude name="ExcessiveParameterList" />
-        <exclude name="ExcessivePublicCount" />
-        <exclude name="GodClass" />
-        <exclude name="LawOfDemeter" />
-        <exclude name="LoosePackageCoupling" />
-        <exclude name="ModifiedCyclomaticComplexity" />
-        <exclude name="NcssConstructorCount" />
-        <exclude name="NcssCount" />
-        <exclude name="NcssMethodCount" />
-        <exclude name="NcssTypeCount" />
-        <exclude name="NPathComplexity" />
-        <exclude name="StdCyclomaticComplexity" />
-        <exclude name="SwitchDensity" />
-        <exclude name="TooManyFields" />
-        <exclude name="TooManyMethods" />
-        <exclude name="UseObjectForClearerAPI" />
-    </rule>
-    <rule ref="category/java/documentation.xml">
-        <exclude name="CommentRequired" />
-        <exclude name="CommentSize" />
-        <exclude name="UncommentedEmptyMethodBody" />
-    </rule>
-    <rule ref="category/java/errorprone.xml">
-        <exclude name="AvoidFieldNameMatchingMethodName" />
-        <exclude name="AvoidLiteralsInIfCondition" />
-        <exclude name="BeanMembersShouldSerialize" />
-        <exclude name="CloseResource" />
-        <exclude name="DataflowAnomalyAnalysis" />
-        <exclude name="DoNotCallSystemExit" />
-        <exclude name="MissingBreakInSwitch" />
-        <exclude name="NonStaticInitializer" />
-        <exclude name="NullAssignment" />
-        <exclude name="ReturnEmptyArrayRatherThanNull" />
-        <exclude name="TestClassWithoutTestCases" />
-    </rule>
-    <rule ref="category/java/multithreading.xml">
-        <exclude name="AvoidSynchronizedAtMethodLevel" />
-        <exclude name="AvoidUsingVolatile" />
-        <exclude name="DoNotUseThreads" />
-        <exclude name="UseConcurrentHashMap" />
-    </rule>
-    <rule ref="category/java/performance.xml">
-        <exclude name="AvoidFileStream" />
-        <exclude name="AvoidInstantiatingObjectsInLoops" />
-        <exclude name="AvoidUsingShortType" />
-        <exclude name="SimplifyStartsWith" />
-        <exclude name="TooFewBranchesForASwitchStatement" />
-    </rule>
-    <rule ref="category/java/security.xml">
-    </rule>
+	xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+	<description>Rules selected by Danilo Pianini</description>
+	<rule ref="category/java/bestpractices.xml">
+		<exclude name="AccessorClassGeneration" />
+		<exclude name="AccessorMethodGeneration" />
+		<exclude name="ConstantsInInterface" />
+		<exclude name="GuardLogStatement" />
+		<exclude name="JUnitAssertionsShouldIncludeMessage" />
+		<exclude name="JUnitTestContainsTooManyAsserts" />
+		<exclude name="JUnitTestsShouldIncludeAssert" />
+		<exclude name="OneDeclarationPerLine" />
+		<exclude name="PositionLiteralsFirstInCaseInsensitiveComparisons" />
+		<exclude name="PositionLiteralsFirstInComparisons" />
+		<exclude name="UseVarargs" />
+	</rule>
+	<rule
+		ref="category/java/bestpractices.xml/AvoidReassigningLoopVariables">
+		<properties>
+			<property name="foreachReassign" value="deny" />
+			<property name="forReassign" value="allow" />
+		</properties>
+	</rule>
+	<rule ref="category/java/codestyle.xml">
+		<exclude name="AbstractNaming" />
+		<exclude name="AtLeastOneConstructor" />
+		<exclude name="AvoidFinalLocalVariable" />
+		<exclude name="AvoidPrefixingMethodParameters" />
+		<exclude name="AvoidUsingNativeCode" />
+		<exclude name="CallSuperInConstructor" />
+		<exclude name="CommentDefaultAccessModifier" />
+		<exclude name="ConfusingTernary" />
+		<exclude name="EmptyMethodInAbstractClassShouldBeAbstract" />
+		<exclude name="LongVariable" />
+		<exclude name="MDBAndSessionBeanNamingConvention" />
+		<exclude name="OnlyOneReturn" />
+		<exclude name="ShortClassName" />
+		<exclude name="ShortMethodName" />
+		<exclude name="ShortVariable" />
+		<exclude name="TooManyStaticImports" />
+	</rule>
+	<rule ref="category/java/codestyle.xml/ClassNamingConventions">
+		<properties>
+			<property name="utilityClassPattern" value="[A-Z][a-zA-Z0-9]+" />
+		</properties>
+	</rule>
+	<rule ref="category/java/design.xml">
+		<exclude name="AbstractClassWithoutAnyMethod" />
+		<exclude name="AvoidDeeplyNestedIfStmts" />
+		<exclude name="CouplingBetweenObjects" />
+		<exclude name="CyclomaticComplexity" />
+		<exclude name="DataClass" />
+		<exclude name="ExcessiveClassLength" />
+		<exclude name="ExcessiveImports" />
+		<exclude name="ExcessiveMethodLength" />
+		<exclude name="ExcessiveParameterList" />
+		<exclude name="ExcessivePublicCount" />
+		<exclude name="GodClass" />
+		<exclude name="LawOfDemeter" />
+		<exclude name="LoosePackageCoupling" />
+		<exclude name="ModifiedCyclomaticComplexity" />
+		<exclude name="NcssConstructorCount" />
+		<exclude name="NcssCount" />
+		<exclude name="NcssMethodCount" />
+		<exclude name="NcssTypeCount" />
+		<exclude name="NPathComplexity" />
+		<exclude name="StdCyclomaticComplexity" />
+		<exclude name="SwitchDensity" />
+		<exclude name="TooManyFields" />
+		<exclude name="TooManyMethods" />
+		<exclude name="UseObjectForClearerAPI" />
+	</rule>
+	<rule ref="category/java/documentation.xml">
+		<exclude name="CommentRequired" />
+		<exclude name="CommentSize" />
+		<exclude name="UncommentedEmptyMethodBody" />
+	</rule>
+	<rule ref="category/java/errorprone.xml">
+		<exclude name="AvoidFieldNameMatchingMethodName" />
+		<exclude name="AvoidLiteralsInIfCondition" />
+		<exclude name="BeanMembersShouldSerialize" />
+		<exclude name="DataflowAnomalyAnalysis" />
+		<exclude name="DoNotCallSystemExit" />
+		<exclude name="MissingBreakInSwitch" />
+		<exclude name="NonStaticInitializer" />
+		<exclude name="NullAssignment" />
+		<exclude name="ReturnEmptyArrayRatherThanNull" />
+		<exclude name="TestClassWithoutTestCases" />
+	</rule>
+	<rule ref="category/java/multithreading.xml">
+		<exclude name="AvoidSynchronizedAtMethodLevel" />
+		<exclude name="AvoidUsingVolatile" />
+		<exclude name="DoNotUseThreads" />
+		<exclude name="UseConcurrentHashMap" />
+	</rule>
+	<rule ref="category/java/performance.xml">
+		<exclude name="AvoidFileStream" />
+		<exclude name="AvoidInstantiatingObjectsInLoops" />
+		<exclude name="AvoidUsingShortType" />
+		<exclude name="SimplifyStartsWith" />
+		<exclude name="TooFewBranchesForASwitchStatement" />
+	</rule>
+	<rule ref="category/java/security.xml">
+	</rule>
 </ruleset>

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/util/ReflectionUtils.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/util/ReflectionUtils.java
@@ -234,8 +234,11 @@ public final class ReflectionUtils {
             return invokePossiblyVoidMethod(method, target, useArgs);
         } catch (Exception exc) { // NOPMD: Generic exception caught by purpose
             /*
-             * Failure: maybe some cast was required?
+             * Failure: maybe some cast was required, if arguments were actually passed?
              */
+            if (useArgs.length == 0) {
+                throw new IllegalStateException(exc);
+            }
             final Class<?>[] params = method.getParameterTypes();
             for (int i = 0; i < params.length; i++) {
                 final Class<?> expected = params[i];

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/AbstractExecutionContext.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/AbstractExecutionContext.java
@@ -21,7 +21,8 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import com.google.common.collect.ImmutableMap;
+import javax.annotation.Nonnull;
+
 import org.protelis.lang.datatype.DatatypeFactory;
 import org.protelis.lang.datatype.DeviceUID;
 import org.protelis.lang.datatype.Field;
@@ -31,15 +32,16 @@ import org.protelis.vm.CodePathFactory;
 import org.protelis.vm.ExecutionContext;
 import org.protelis.vm.ExecutionEnvironment;
 import org.protelis.vm.NetworkManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.stack.TIntStack;
 import gnu.trove.stack.array.TIntArrayStack;
-
-import javax.annotation.Nonnull;
 
 /**
  * Partial implementation of ExecutionContext, containing functionality expected
@@ -57,6 +59,7 @@ import javax.annotation.Nonnull;
 public abstract class AbstractExecutionContext<S extends AbstractExecutionContext<S>> implements ExecutionContext {
 
     private static final int MASK = 0xFF;
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExecutionContext.class);
     private final TIntStack callFrameSizes = new TIntArrayStack();
     private final TIntList callStack = new TIntArrayList(10, -1);
     private final CodePathFactory codePathFactory;
@@ -130,7 +133,6 @@ public abstract class AbstractExecutionContext<S extends AbstractExecutionContex
                 builder.add(e.getKey(), computeValue.apply((T) received));
             }
         }
-        final Field<R> result = builder.build(getDeviceUID(), computeValue.apply(Objects.requireNonNull(localValue)));
         /*
          * If a field is computed locally, the local value should get echoed to
          * neighbors. However, such operation must be performed *after* the build
@@ -145,7 +147,7 @@ public abstract class AbstractExecutionContext<S extends AbstractExecutionContex
                             + " into " + toSend + ". Value to insert: " + localValue + ", existing one: " + toSend.get(codePath)
             );
         }
-        return result;
+        return builder.build(getDeviceUID(), computeValue.apply(Objects.requireNonNull(localValue)));
     }
 
     @Override
@@ -347,6 +349,20 @@ public abstract class AbstractExecutionContext<S extends AbstractExecutionContex
         gamma = newLinkedHashMapWithExpectedSize(variablesSize);
         gamma.putAll(functions.orElseGet(Collections::emptyMap));
         theta = Collections.unmodifiableMap(nm.getNeighborState());
+        if (theta.containsKey(getDeviceUID())) {
+            LOGGER.warn("Local device UID {} was included in the set of received messages, "
+                    + "indicating that an auto-arc was present in your network configuration. "
+                    + "This is being worked around by not considering such information, "
+                    + "however, you should fix your logical netowrk.", getDeviceUID());
+            final ImmutableMap.Builder<DeviceUID, Map<CodePath, Object>> immutableMap = ImmutableMap
+                    .builderWithExpectedSize(theta.size() - 1);
+            theta.forEach((id, object) -> {
+                if (!id.equals(getDeviceUID())) {
+                    immutableMap.put(id, object);
+                }
+            });
+            theta = immutableMap.build();
+        }
         newCallStackFrame(-1);
     }
 

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/DefaultTimeEfficientCodePath.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/DefaultTimeEfficientCodePath.java
@@ -20,6 +20,7 @@ import org.protelis.vm.CodePath;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import gnu.trove.list.TIntList;
 
 /**
@@ -31,9 +32,10 @@ public final class DefaultTimeEfficientCodePath implements CodePath {
     private static final long serialVersionUID = 2L;
     private static final Map<Integer, Bytecode> REVERSE_LOOKUP_BYTECODE = Arrays.stream(Bytecode.values())
           .collect(Collectors.toMap(Bytecode::getCode, Function.identity()));
-
     private final int[] repr;
+    @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
     private transient int lazyHash;
+    @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
     private transient String lazyString;
 
     /**

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/DefaultTimeEfficientCodePath.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/vm/impl/DefaultTimeEfficientCodePath.java
@@ -9,7 +9,12 @@
 package org.protelis.vm.impl;
 
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import org.protelis.lang.interpreter.util.Bytecode;
 import org.protelis.vm.CodePath;
 
 import com.google.common.hash.Hasher;
@@ -23,9 +28,13 @@ import gnu.trove.list.TIntList;
  */
 public final class DefaultTimeEfficientCodePath implements CodePath {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
+    private static final Map<Integer, Bytecode> REVERSE_LOOKUP_BYTECODE = Arrays.stream(Bytecode.values())
+          .collect(Collectors.toMap(Bytecode::getCode, Function.identity()));
+
     private final int[] repr;
-    private int lazyHash;
+    private transient int lazyHash;
+    private transient String lazyString;
 
     /**
      * @param source the current stack frames identifiers
@@ -54,7 +63,14 @@ public final class DefaultTimeEfficientCodePath implements CodePath {
 
     @Override
     public String toString() {
-        return "CodePath" + Arrays.toString(repr);
+        if (lazyString == null) {
+            lazyString = "CodePath" + Arrays.stream(repr)
+                .mapToObj(it -> Optional.ofNullable(REVERSE_LOOKUP_BYTECODE.get(it))
+                        .map(Object::toString)
+                        .orElse(Integer.toString(it)))
+                .collect(Collectors.joining("->", "[", "]"));
+        }
+        return lazyString;
     }
 
 }


### PR DESCRIPTION
There was a corner case that I hit in one experiment where a bug in the network manager caused `self.nbrRange()` to fail miserably with an extremely cryptic error message, whose only clear portion was that there was a likely bug in Protelis.
It was not actually a bug in Protelis, but an unfortunate design of a `NetworkManager` implementation which ended up hitting a number of uncontrolled paths in protelis code, ultimately making it failing at failing fast enough, hence at providing correct references for bug resolution.

The issue is mitigated as follows:
* Default code paths now can be better read as strings, and their trace actually makes some sense (if you know how the interpreter works...). Helps with debug.
* A special condition (invoking a 0-ary method) now has a fail-fast path, which does not attempt to re-invoke a method after failure in the hope for casts to be required
* The bug is finally prevented from causing pollution into the message queue, echoing the error to subsequent rounds and nearby devices. 