### PR TITLE
Fix for multiInstance over sharing

### DIFF
--- a/protelis/protelis-lang/src/main/protelis/protelis/coord/meta.pt
+++ b/protelis/protelis-lang/src/main/protelis/protelis/coord/meta.pt
@@ -63,7 +63,7 @@ public def findSourcesWithId(source, id, d, k) {
 public def multiInstance(sources, f, null) {
     alignedMap(
         nbr(sources.map(self, id -> {[id, null]})),
-        (key, field) -> { true },
+        (key, field) -> { sources.contains(key) },
         (key, field) -> { f.apply(key) },
         null
     )


### PR DESCRIPTION
multiInstance needs to not extend outside of the list of
sources passed in.

@jakebeal  and I ran into a problem with multiInstance sharing information too far. This fixes the problem.