### PR TITLE
Upgrade logback-classic from 1.2.3 to 1.3.0-alpha5

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -19,8 +19,7 @@ plugin.org.jlleitschuh.gradle.ktlint=9.0.0
 
 plugin.org.protelis.protelisdoc=0.2.0
 
-version.ch.qos.logback..logback-classic=1.2.3
-##                          # available=1.3.0-alpha5
+version.ch.qos.logback..logback-classic=1.3.0-alpha5
 
 version.com.github.spotbugs..spotbugs-annotations=4.0.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.