### PR TITLE
Upgrade alchemist-interfaces from 4.0.0 to 9.3.0

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -35,8 +35,7 @@ version.de.ruedigermoeller..fst=2.57
 version.io.github.classgraph..classgraph=4.8.65
 ##                           # available=4.8.68
 
-version.it.unibo.alchemist..alchemist-interfaces=4.0.0
-##                                   # available=9.3.0
+version.it.unibo.alchemist..alchemist-interfaces=9.3.0
 
 version.it.unibo.alchemist..alchemist-loading=4.0.0
 ##                                # available=9.3.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.