### PR TITLE
Upgrade com.jfrog.bintray from 1.8.4 to 1.8.5

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -6,8 +6,7 @@
 
 plugin.com.github.spotbugs=4.0.5
 
-plugin.com.jfrog.bintray=1.8.4
-##           # available=1.8.5
+plugin.com.jfrog.bintray=1.8.5
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.