### PR TITLE
Upgrade org.protelis.protelisdoc from 0.2.0 to 0.2.2

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -14,7 +14,7 @@ plugin.org.danilopianini.publish-on-central=0.2.3
 
 plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 
-plugin.org.protelis.protelisdoc=0.2.0
+plugin.org.protelis.protelisdoc=0.2.2
 
 version.ch.qos.logback..logback-classic=1.2.3
 ##                          # available=1.3.0-alpha5
@@ -30,7 +30,7 @@ version.commons-io..commons-io=2.6
 version.de.ruedigermoeller..fst=2.57
 
 version.io.github.classgraph..classgraph=4.8.65
-##                           # available=4.8.68
+##                           # available=4.8.69
 
 version.it.unibo.alchemist..alchemist-interfaces=4.0.0
 ##                                   # available=9.3.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.