### PR TITLE
Upgrade org.protelis.protelisdoc from 0.2.0 to 0.2.2

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -14,8 +14,7 @@ plugin.org.danilopianini.publish-on-central=0.2.3
 
 plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 
-plugin.org.protelis.protelisdoc=0.2.0
-##                  # available=0.2.1
+plugin.org.protelis.protelisdoc=0.2.2
 
 version.ch.qos.logback..logback-classic=1.2.3
 ##                          # available=1.3.0-alpha5


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.