### PR TITLE
Upgrade guava from 28.2-jre to 29.0-jre

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -21,7 +21,7 @@ version.ch.qos.logback..logback-classic=1.2.3
 
 version.com.github.spotbugs..spotbugs-annotations=4.0.1
 
-version.com.google.guava..guava=28.2-jre
+version.com.google.guava..guava=29.0-jre
 
 version.commons-codec..commons-codec=1.14
 
@@ -40,6 +40,7 @@ version.it.unibo.alchemist..alchemist-loading=4.0.0
 version.junit.junit=4.13
 
 version.kotlin=1.3.71
+## # available=1.3.72
 
 version.net.sf.trove4j..trove4j=3.0.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.