### PR TITLE
Upgrade logback-classic from 1.2.3 to 1.3.0-alpha5

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -15,11 +15,12 @@ plugin.org.danilopianini.publish-on-central=0.2.3
 plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 
 plugin.org.protelis.protelisdoc=0.3.0
+##                  # available=0.3.1
 
-version.ch.qos.logback..logback-classic=1.2.3
-##                          # available=1.3.0-alpha5
+version.ch.qos.logback..logback-classic=1.3.0-alpha5
 
 version.com.github.spotbugs..spotbugs-annotations=4.0.1
+##                                    # available=4.0.2
 
 version.com.google.guava..guava=28.2-jre
 ##                  # available=29.0-jre


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.