### PR TITLE
Upgrade slf4j-api from 1.7.30 to 1.8.0-beta4

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -15,11 +15,13 @@ plugin.org.danilopianini.publish-on-central=0.2.3
 plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 
 plugin.org.protelis.protelisdoc=0.3.0
+##                  # available=0.3.1
 
 version.ch.qos.logback..logback-classic=1.2.3
 ##                          # available=1.3.0-alpha5
 
 version.com.github.spotbugs..spotbugs-annotations=4.0.1
+##                                    # available=4.0.2
 
 version.com.google.guava..guava=28.2-jre
 ##                  # available=29.0-jre
@@ -52,6 +54,5 @@ version.org.jboss.apiviz..apiviz=1.3.2.GA
 
 version.org.protelis..protelis.parser=10.0.2
 
-version.org.slf4j..slf4j-api=1.7.30
-##               # available=1.8.0-beta4
+version.org.slf4j..slf4j-api=1.8.0-beta4
 ##               # available=2.0.0-alpha1


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.