### PR TITLE
Upgrade classgraph from 4.8.70 to 4.8.71

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -29,7 +29,7 @@ version.commons-io..commons-io=2.6
 
 version.de.ruedigermoeller..fst=2.57
 
-version.io.github.classgraph..classgraph=4.8.70
+version.io.github.classgraph..classgraph=4.8.71
 
 version.it.unibo.alchemist..alchemist-interfaces=4.0.0
 ##                                   # available=9.3.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.