### PR TITLE
Upgrade guava from 28.2-jre to 29.0-jre

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -20,8 +20,7 @@ version.ch.qos.logback..logback-classic=1.3.0-alpha5
 
 version.com.github.spotbugs..spotbugs-annotations=4.0.2
 
-version.com.google.guava..guava=28.2-jre
-##                  # available=29.0-jre
+version.com.google.guava..guava=29.0-jre
 
 version.commons-codec..commons-codec=1.14
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.