### PR TITLE
Upgrade classgraph from 4.8.84 to 4.8.85

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -28,7 +28,7 @@ version.commons-io..commons-io=2.7
 
 version.de.ruedigermoeller..fst=2.57
 
-version.io.github.classgraph..classgraph=4.8.84
+version.io.github.classgraph..classgraph=4.8.85
 
 version.it.unibo.alchemist..alchemist-interfaces=4.0.0
 ##                                   # available=9.3.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.