### PR TITLE
Upgrade spotbugs-annotations from 4.0.5 to 4.0.6

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -18,7 +18,7 @@ plugin.org.protelis.protelisdoc=0.3.1
 
 version.ch.qos.logback..logback-classic=1.3.0-alpha5
 
-version.com.github.spotbugs..spotbugs-annotations=4.0.5
+version.com.github.spotbugs..spotbugs-annotations=4.0.6
 
 version.com.google.guava..guava=29.0-jre
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.