### PR TITLE
Upgrade commons-lang3 from 3.10 to 3.11

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -38,7 +38,7 @@ version.kotlin=1.3.72
 
 version.net.sf.trove4j..trove4j=3.0.3
 
-version.org.apache.commons..commons-lang3=3.10
+version.org.apache.commons..commons-lang3=3.11
 
 version.org.apache.commons..commons-math3=3.6.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.