### PR TITLE
Upgrade protelisdoc from 0.3.1 to 0.3.2

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -14,7 +14,7 @@ plugin.org.danilopianini.publish-on-central=0.2.3
 
 plugin.org.jlleitschuh.gradle.ktlint=9.3.0
 
-plugin.org.protelis.protelisdoc=0.3.1
+plugin.org.protelis.protelisdoc=0.3.2
 
 version.ch.qos.logback..logback-classic=1.3.0-alpha5
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.