### PR TITLE
Upgrade kotlin from 1.4.0-rc to 1.4.0

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -34,7 +34,7 @@ version.it.unibo.alchemist=4.0.0
 
 version.junit.junit=4.13
 
-version.kotlin=1.4.0-rc
+version.kotlin=1.4.0
 
 version.net.sf.trove4j..trove4j=3.0.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.