### PR TITLE
Upgrade publish-on-central from 0.2.3 to 0.3.0

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -10,7 +10,7 @@ plugin.com.jfrog.bintray=1.8.5
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
-plugin.org.danilopianini.publish-on-central=0.2.3
+plugin.org.danilopianini.publish-on-central=0.3.0
 
 plugin.org.jlleitschuh.gradle.ktlint=9.3.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.