### PR TITLE
Upgrade commons-io from 2.7 to 2.8.0

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -24,7 +24,7 @@ version.com.google.guava..guava=29.0-jre
 
 version.commons-codec..commons-codec=1.15
 
-version.commons-io..commons-io=2.7
+version.commons-io..commons-io=2.8.0
 
 version.de.ruedigermoeller..fst=2.57
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.