### PR TITLE
Upgrade classgraph from 4.8.89 to 4.8.90

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -28,7 +28,7 @@ version.commons-io..commons-io=2.8.0
 
 version.de.ruedigermoeller..fst=2.57
 
-version.io.github.classgraph..classgraph=4.8.89
+version.io.github.classgraph..classgraph=4.8.90
 
 version.it.unibo.alchemist=4.0.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.