### PR TITLE
Upgrade junit from 4.13 to 4.13.1

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -32,7 +32,7 @@ version.io.github.classgraph..classgraph=4.8.90
 
 version.it.unibo.alchemist=4.0.0
 
-version.junit.junit=4.13
+version.junit.junit=4.13.1
 
 version.net.sf.trove4j..trove4j=3.0.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.