### PR TITLE
Upgrade commons-io from 2.8.0 to 20030203.000550

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -24,7 +24,7 @@ version.com.google.guava..guava=30.0-jre
 
 version.commons-codec..commons-codec=1.15
 
-version.commons-io..commons-io=2.8.0
+version.commons-io..commons-io=20030203.000550
 
 version.de.ruedigermoeller..fst=2.57
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.