### PR TITLE
Upgrade guava from 30.0-jre to 30.1-jre

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -20,7 +20,7 @@ version.ch.qos.logback..logback-classic=1.3.0-alpha5
 
 version.com.github.spotbugs..spotbugs-annotations=4.2.0
 
-version.com.google.guava..guava=30.0-jre
+version.com.google.guava..guava=30.1-jre
 
 version.commons-codec..commons-codec=1.15
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.