### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.2 to 0.2.3

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -8,7 +8,7 @@ plugin.com.github.spotbugs=4.6.0
 
 plugin.com.jfrog.bintray=1.8.5
 
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
 
 plugin.org.danilopianini.publish-on-central=0.4.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.