### PR TITLE
Tuple.zip

### DIFF
--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/Tuple.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/Tuple.java
@@ -24,30 +24,27 @@ public interface Tuple extends Iterable<Object>, Serializable, Comparable<Tuple>
     /**
      * Add an element to the end of a tuple. Equivalent to insert(size,
      * element).
-     * 
-     * @param element
-     *            Element to be added
+     *
+     * @param element Element to be added
      * @return A new tuple with equal to the current plus the new element added
-     *         to the end
+     * to the end
      */
     Tuple append(Object element);
 
     /**
      * Tests whether the tuple has an element equal to its argument.
-     * 
-     * @param element
-     *            Element to test whether it is equal to any element in the
-     *            tuple
+     *
+     * @param element Element to test whether it is equal to any element in the
+     *                tuple
      * @return true if the tuple contains an element equal to "element"
      */
     boolean contains(Object element);
 
     /**
      * Tests whether the tuple has an element equal to its argument.
-     * 
-     * @param element
-     *            Element to test whether it is equal to any element in the
-     *            tuple
+     *
+     * @param element Element to test whether it is equal to any element in the
+     *                tuple
      * @return true if the tuple contains an element equal to "element"
      */
     boolean containsAll(Iterable<?> element);
@@ -55,11 +52,9 @@ public interface Tuple extends Iterable<Object>, Serializable, Comparable<Tuple>
     /**
      * Given a tuple and a predicate, returns a new tuple containing only the
      * elements that match the predicate.
-     * 
-     * @param ctx
-     *            the current execution context
-     * @param fun
-     *            the predicate
+     *
+     * @param ctx the current execution context
+     * @param fun the predicate
      * @return a new tuple containing only the elements that match the predicate
      */
     Tuple filter(ExecutionContext ctx, FunctionDefinition fun);
@@ -67,61 +62,54 @@ public interface Tuple extends Iterable<Object>, Serializable, Comparable<Tuple>
     /**
      * Given a tuple and a {@link Predicate}, returns a new tuple containing
      * only the elements that match the predicate.
-     * 
-     * @param fun
-     *            the {@link Predicate}
+     *
+     * @param fun the {@link Predicate}
      * @return a new tuple containing only the elements that match the
-     *         {@link Predicate}
+     * {@link Predicate}
      */
     Tuple filter(Predicate<Object> fun);
 
     /**
      * Retrieve the object at one of a tuple's indices.
-     * 
-     * @param i
-     *            Zero-based index of the object to be retrieved
+     *
+     * @param i Zero-based index of the object to be retrieved
      * @return The object at index i
      */
     Object get(int i);
 
     /**
      * @return the first element of the tuple if present, throws an exception otherwise
-     * 
      * @throws ArrayIndexOutOfBoundsException if there are no elements in the tuple
      */
     Object head();
 
     /**
      * Searches for an element in a tuple, returning its index if found.
-     * 
-     * @param element
-     *            The object to be searched for
+     *
+     * @param element The object to be searched for
      * @return The first index where the search object is found, or -1 if not
-     *         found
+     * found
      */
     int indexof(Object element);
 
     /**
      * Add an element to an arbitrary location within a tuple, moving all
      * elements after it down.
-     * 
-     * @param i
-     *            Zero-based index at which the element is to be added
-     * @param element
-     *            Element to be added
+     *
+     * @param i       Zero-based index at which the element is to be added
+     * @param element Element to be added
      * @return A new tuple with equal to the current plus the new element added
-     *         at the given index
+     * at the given index
      */
     Tuple insert(int i, Object element);
 
     /**
      * Set arithmetic: compute intersection of set of tuple elements with set of
      * elements of another tuple.
-     * 
-     * @param t
-     *            tuple to take intersection with
+     *
+     * @param t tuple to take intersection with
      * @return a new tuple containing elements appearing in both tuples, in
-     *         arbitrary order
+     * arbitrary order
      */
     Tuple intersection(Tuple t);
 
@@ -133,11 +121,9 @@ public interface Tuple extends Iterable<Object>, Serializable, Comparable<Tuple>
     /**
      * Maps a tuple to another same-length tuple by applying a function to each
      * element.
-     * 
-     * @param ctx
-     *            the current execution context
-     * @param fun
-     *            the function to apply
+     *
+     * @param ctx the current execution context
+     * @param fun the function to apply
      * @return a new tuple containing the values
      */
     Tuple map(ExecutionContext ctx, FunctionDefinition fun);
@@ -145,83 +131,71 @@ public interface Tuple extends Iterable<Object>, Serializable, Comparable<Tuple>
     /**
      * Maps a tuple to another same-length tuple by applying a function to each
      * element.
-     * 
-     * @param fun
-     *            the function to apply
+     *
+     * @param fun the function to apply
      * @return a new tuple containing the values
      */
     Tuple map(Function<Object, Object> fun);
 
     /**
-     * @param def
-     *            the return in case max is not defined
+     * @param def the return in case max is not defined
      * @return the biggest element of this tuple, if defined, or default
-     *         otherwise
+     * otherwise
      */
     Object max(Object def);
 
     /**
      * Append elements of another tuple to the end of this tuple.
-     * 
-     * @param tuple
-     *            tuple to be added
+     *
+     * @param tuple tuple to be added
      * @return a new tuple
      */
     Tuple mergeAfter(Tuple tuple);
 
     /**
-     * @param def
-     *            the return in case min is not defined
+     * @param def the return in case min is not defined
      * @return the smallest element of this tuple, if defined, or default
-     *         otherwise
+     * otherwise
      */
     Object min(Object def);
 
     /**
      * Add an element to the start of a tuple. Equivalent to insert(0, element).
-     * 
-     * @param element
-     *            Element to be added
+     *
+     * @param element Element to be added
      * @return A new tuple with equal to the current plus the new element added
-     *         to the start
+     * to the start
      */
     Tuple prepend(Object element);
 
     /**
      * Performs a reduction operation, that maps a tuple to a single value.
-     * 
-     * @param ctx
-     *            the current execution context
-     * @param defVal
-     *            the value that will be returned if the tuple is empty
-     * @param fun
-     *            the {@link BinaryOperator} that will be applied to each couple
-     *            of values
+     *
+     * @param ctx    the current execution context
+     * @param defVal the value that will be returned if the tuple is empty
+     * @param fun    the {@link BinaryOperator} that will be applied to each couple
+     *               of values
      * @return a single value of this tuple, or the default value if empty
      */
     Object reduce(ExecutionContext ctx, Object defVal, FunctionDefinition fun);
 
     /**
      * Performs a reduction operation, that maps a tuple to a single value.
-     * 
-     * @param defVal
-     *            the value that will be returned if the tuple is empty
-     * @param fun
-     *            the {@link BinaryOperator} that will be applied to each couple
-     *            of values
+     *
+     * @param defVal the value that will be returned if the tuple is empty
+     * @param fun    the {@link BinaryOperator} that will be applied to each couple
+     *               of values
      * @return a single value of this tuple, or the default value if empty
      */
     Object reduce(Object defVal, BinaryOperator<Object> fun);
 
     /**
      * Replace an element in a tuple.
-     * 
-     * @param i
-     *            Zero-based index at which the element is to be replaced
-     * @param element
-     *            Element to replace the current element
+     *
+     * @param i       Zero-based index at which the element is to be replaced
+     * @param element Element to replace the current element
      * @return A new tuple with the element at the ith index replaced by
-     *         "element"
+     * "element"
      */
     Tuple set(int i, Object element);
 
@@ -238,9 +212,8 @@ public interface Tuple extends Iterable<Object>, Serializable, Comparable<Tuple>
     /**
      * Set arithmetic: compute which elements in this tuple are not in another
      * tuple.
-     * 
-     * @param t
-     *            tuple to subtract
+     *
+     * @param t tuple to subtract
      * @return a new tuple containing elements not in t, in arbitrary order
      */
     Tuple subtract(Tuple t);
@@ -248,11 +221,9 @@ public interface Tuple extends Iterable<Object>, Serializable, Comparable<Tuple>
     /**
      * Produces a new Tuple containing the elements between the start and end
      * indices. The start index is inclusive, the end index exclusive.
-     * 
-     * @param i
-     *            start index
-     * @param j
-     *            end index
+     *
+     * @param i start index
+     * @param j end index
      * @return a new tuple containing elements i through j-1
      */
     Tuple subTuple(int i, int j);
@@ -260,9 +231,8 @@ public interface Tuple extends Iterable<Object>, Serializable, Comparable<Tuple>
     /**
      * Produces a new Tuple containing all elements from i onward. Equivalent to
      * subTuple(i,Tuple.size()).
-     * 
-     * @param i
-     *            First element to take for new tuple
+     *
+     * @param i First element to take for new tuple
      * @return a new tuple containing elements i through size-1
      */
     Tuple subTupleEnd(int i);
@@ -270,16 +240,14 @@ public interface Tuple extends Iterable<Object>, Serializable, Comparable<Tuple>
     /**
      * Produces a new Tuple containing the first i elements. Equivalent to
      * subTuple(0,i).
-     * 
-     * @param i
-     *            Number of elements to take
+     *
+     * @param i Number of elements to take
      * @return a new tuple containing elements 0 through i-1
      */
     Tuple subTupleStart(int i);
 
     /**
      * @return a tuple with all the element of this tuple except the first
-     * 
      * @throws ArrayIndexOutOfBoundsException if there are no elements in the tuple
      */
     Tuple tail();
@@ -292,21 +260,32 @@ public interface Tuple extends Iterable<Object>, Serializable, Comparable<Tuple>
     /**
      * Set arithmetic: compute union of set of tuple elements with set of
      * elements of another tuple.
-     * 
-     * @param t
-     *            tuple to take union with
+     *
+     * @param t tuple to take union with
      * @return a new tuple containing elements appearing in either tuple, in
-     *         arbitrary order
+     * arbitrary order
      */
     Tuple union(Tuple t);
 
     /**
      * For all elements that are tuples, substitute the ith sub-element. For
      * example: [[1,2],3,[4,5],6].unwrap(1) produces [2,3,5,6].
-     * 
-     * @param i
-     *            index of sub-element to substitute
+     *
+     * @param i index of sub-element to substitute
      * @return a new tuple with substituted elements
      */
     Tuple unwrap(int i);
+
+    /**
+     * Zips two tuples together, creating a Tuple of 2-ples.
+     * In case the tuple size differs, the zipping tuple will create a tuple whose length matches the smaller one,
+     * discarding elements of the longer one:
+     *
+     * [1, 2, 3].zip([4, 5]) returns [[1, 4], [2, 5]]
+     *
+     * @param other the tuple to zip this one with
+     * @return A tuple of pairs (tuples of two elements) containing elements with the same index in this tuple and the
+     * provided one.
+     */
+    Tuple zip(Tuple other);
 }

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/impl/ArrayTupleImpl.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/impl/ArrayTupleImpl.java
@@ -8,7 +8,6 @@
  *******************************************************************************/
 package org.protelis.lang.datatype.impl;
 
-import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
@@ -34,7 +33,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 /**
  * Implementation of a Tuple using an array data structure.
@@ -356,7 +354,7 @@ public final class ArrayTupleImpl implements Tuple {
     @Override
     public Tuple sort() {
         final Object[] newArray = Arrays.copyOf(arrayContents, arrayContents.length);
-        Arrays.sort(newArraqy, COMPARE_TO);
+        Arrays.sort(newArray, COMPARE_TO);
         return DatatypeFactory.createTuple(newArray);
     }
 
@@ -439,6 +437,15 @@ public final class ArrayTupleImpl implements Tuple {
         }).toArray());
     }
 
+    @Override
+    public Tuple zip(final Tuple other) {
+        final Object[] result = new Object[Math.min(size(), other.size())];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = new ArrayTupleImpl(new Object[]{ get(i), other.get(i) }, false);
+        }
+        return new ArrayTupleImpl(result, false);
+    }
+
     private static int compareLexicographically(final Object a, final Object b) {
         return a.toString().compareTo(b.toString());
     }
@@ -446,5 +453,4 @@ public final class ArrayTupleImpl implements Tuple {
     private static List<ProtelisAST<?>> elementAsArguments(final Object element) {
         return ImmutableList.of(new Constant<>(JavaInteroperabilityUtils.METADATA, element));
     }
-
 }


### PR DESCRIPTION
This PR adds to Protelis a Tuple.zip method, allowing to merge two tuples to a tuple of pairs (tuples of two elements) containing elements with the same index.

I also took the chance to improve the overall performance of tuples (they were creating useless intermediate arrays).

There's no retrocompatibility issue, it's an API extension.

@jakebeal let me know if this works for you, and I'll rebase-merge this into develop and release a new protelis (14.2.0 presumably).