### PR TITLE
Upgrade classgraph from 4.8.100 to 4.8.102

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -30,7 +30,7 @@ version.commons-io..commons-io=2.8.0
 
 version.de.ruedigermoeller..fst=2.57
 
-version.io.github.classgraph..classgraph=4.8.100
+version.io.github.classgraph..classgraph=4.8.102
 
 version.it.unibo.alchemist=4.0.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.