### PR TITLE
Implement a more efficient get-if-present

### DIFF
--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/Field.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/Field.java
@@ -11,6 +11,7 @@ package org.protelis.lang.datatype;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -160,8 +161,7 @@ public interface Field<T> extends Serializable {
      *                                among its keys
      */
     default T get(@Nonnull DeviceUID id) {
-        return stream().filter(it -> it.getKey().equals(id)).findFirst()
-            .map(Map.Entry::getValue)
+        return getIfPresent(id)
             .orElseThrow(() -> new NoSuchElementException("Device " + id + " is not available in field " + this));
     }
 
@@ -171,6 +171,16 @@ public interface Field<T> extends Serializable {
     @SuppressWarnings("unchecked")
     default Class<? extends T> getExpectedType() {
         return (Class<? extends T>) getLocal().getValue().getClass();
+    }
+
+    /**
+     * @param id the DeviceUID
+     * @return the associated value wrapped in an {@link Optional},
+     *         or an {@link Optional#empty()} if the device is not aligned.
+     */
+    default Optional<T> getIfPresent(@Nonnull DeviceUID id) {
+        return stream().filter(it -> it.getKey().equals(id)).findFirst()
+            .map(Map.Entry::getValue);
     }
 
     /**

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/impl/FieldMapImpl.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/impl/FieldMapImpl.java
@@ -11,11 +11,13 @@ package org.protelis.lang.datatype.impl;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.jetbrains.annotations.NotNull;
 import org.protelis.lang.datatype.DeviceUID;
 import org.protelis.lang.datatype.Field;
 
 import javax.annotation.Nonnull;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -39,6 +41,11 @@ public final class FieldMapImpl<T> extends AbstractField<T> { // NOPMD: a builde
     @Override
     public boolean containsKey(final DeviceUID id) {
         return values.containsKey(id);
+    }
+
+    @Override
+    public Optional<T> getIfPresent(@NotNull final DeviceUID device) {
+        return Optional.ofNullable(values.get(device));
     }
 
     @Override

--- a/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/impl/LazyField.java
+++ b/protelis/protelis-interpreter/src/main/java/org/protelis/lang/datatype/impl/LazyField.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -115,8 +116,8 @@ public final class LazyField<T> extends AbstractField<T> {
     }
 
     @Override
-    public T get(@Nonnull final DeviceUID id) {
-        final T result = neighbors.getUnchecked(id);
+    public Optional<T> getIfPresent(@Nonnull final DeviceUID id) {
+        final Optional<T> result = Optional.ofNullable(neighbors.getUnchecked(id));
         /*
          * Check for cache population completion
          */


### PR DESCRIPTION
Besides a marginal speed-up, this change should allow for an easier and faster implementation of the `exchange` primitive, implementing per-neighbor communications in Protelis.