### PR TITLE
Upgrade junit from 4.13.1 to 4.13.2

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -34,7 +34,7 @@ version.io.github.classgraph..classgraph=4.8.102
 
 version.it.unibo.alchemist=4.0.0
 
-version.junit.junit=4.13.1
+version.junit.junit=4.13.2
 
 version.net.sf.trove4j..trove4j=3.0.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.