### PR TITLE
Upgrade spotbugs from 4.6.0 to 4.6.2

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -6,7 +6,7 @@
 
 plugin.com.github.johnrengelman.shadow=6.1.0
 
-plugin.com.github.spotbugs=4.6.0
+plugin.com.github.spotbugs=4.6.2
 
 plugin.com.jfrog.bintray=1.8.5
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.