### PR TITLE
Upgrade commons-lang3 from 3.11 to 3.12.0

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -42,7 +42,7 @@ version.net.sourceforge.pmd..pmd-core=6.32.0
 
 version.net.sourceforge.pmd..pmd-java=version.net.sourceforge.pmd..pmd-core
 
-version.org.apache.commons..commons-lang3=3.11
+version.org.apache.commons..commons-lang3=3.12.0
 
 version.org.apache.commons..commons-math3=3.6.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.