### PR TITLE
Upgrade spotbugs-annotations from 4.2.1 to 4.2.2

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -20,7 +20,7 @@ plugin.org.protelis.protelisdoc=0.4.0
 
 version.ch.qos.logback..logback-classic=1.3.0-alpha5
 
-version.com.github.spotbugs..spotbugs-annotations=4.2.1
+version.com.github.spotbugs..spotbugs-annotations=4.2.2
 
 version.com.google.guava..guava=30.1-jre
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.