### PR TITLE
Upgrade Gradle Wrapper to 7.0

### DIFF
--- a/protelis/build.gradle.kts
+++ b/protelis/build.gradle.kts
@@ -81,6 +81,10 @@ allprojects {
         options.encoding = "UTF-8"
     }
 
+    tasks.withType<AbstractCopyTask> {
+        duplicatesStrategy = DuplicatesStrategy.WARN
+    }
+
     tasks.withType<Test> {
         failFast = true
         testLogging {

--- a/protelis/gradle/wrapper/gradle-wrapper.properties
+++ b/protelis/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request upgrades the Gradle wrapper in project 
from 6.8.3 to 7.0.                       