### PR TITLE
Upgrade publish-on-central from 0.4.3 to 0.4.4

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -12,7 +12,7 @@ plugin.com.jfrog.bintray=1.8.5
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
 
-plugin.org.danilopianini.publish-on-central=0.4.3
+plugin.org.danilopianini.publish-on-central=0.4.4
 
 plugin.org.jlleitschuh.gradle.ktlint=10.0.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.