### PR TITLE
Upgrade alchemist from 4.0.0 to 11.2.0

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -32,7 +32,7 @@ version.de.ruedigermoeller..fst=2.57
 
 version.io.github.classgraph..classgraph=4.8.108
 
-version.it.unibo.alchemist=4.0.0
+version.it.unibo.alchemist=11.2.0
 
 version.junit.junit=4.13.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.