### PR TITLE
Upgrade classgraph from 4.8.105 to 4.8.106

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -30,7 +30,7 @@ version.commons-io..commons-io=2.8.0
 
 version.de.ruedigermoeller..fst=2.57
 
-version.io.github.classgraph..classgraph=4.8.105
+version.io.github.classgraph..classgraph=4.8.106
 
 version.it.unibo.alchemist=4.0.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.