### PR TITLE
Upgrade publish-on-central from 0.4.4 to 0.5.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -12,7 +12,7 @@ plugin.com.jfrog.bintray=1.8.5
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
 
-plugin.org.danilopianini.publish-on-central=0.4.4
+plugin.org.danilopianini.publish-on-central=0.5.0
 
 plugin.org.jlleitschuh.gradle.ktlint=10.1.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.