### PR TITLE
Upgrade alchemist from 4.0.0 to 5.0.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -35,7 +35,7 @@ version.commons-io..commons-io=2.11.0
 
 version.io.github.classgraph..classgraph=4.8.110
 
-version.it.unibo.alchemist=4.0.0
+version.it.unibo.alchemist=5.0.0
 
 version.it.unibo.alchemist..alchemist-interfaces=11.2.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.