### PR TITLE
Upgrade commons-io from 2.9.0 to 2.10.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -29,7 +29,7 @@ version.com.google.guava..guava=30.1.1-jre
 
 version.commons-codec..commons-codec=1.15
 
-version.commons-io..commons-io=2.9.0
+version.commons-io..commons-io=2.10.0
 
 version.io.github.classgraph..classgraph=4.8.108
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.