### PR TITLE
Upgrade spotbugs-annotations from 4.2.3 to 4.3.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -23,7 +23,7 @@ plugin.org.protelis.protelisdoc=0.4.0
 
 version.ch.qos.logback..logback-classic=1.3.0-alpha5
 
-version.com.github.spotbugs..spotbugs-annotations=4.2.3
+version.com.github.spotbugs..spotbugs-annotations=4.3.0
 
 version.com.google.guava..guava=30.1.1-jre
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.