### PR TITLE
Upgrade slf4j-api from 1.7.31 to 1.7.32

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -57,4 +57,4 @@ version.org.jboss.apiviz..apiviz=1.3.2.GA
 
 version.org.protelis..protelis.parser=10.2.0
 
-version.org.slf4j..slf4j-api=1.7.31
+version.org.slf4j..slf4j-api=1.7.32


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.