### PR TITLE
Write a tentative parallel S

### DIFF
--- a/protelis-lang/src/main/protelis/protelis/coord/sparsechoice.pt
+++ b/protelis-lang/src/main/protelis/protelis/coord/sparsechoice.pt
@@ -42,33 +42,33 @@ def tieBreakerOf(tuple) = [tuple.get(1).get(0), tuple.get(0)]
 /**
  * Devices compete against one another to become local leaders,
  * resulting  in  a  random  Voronoi  partition  with  a  characteristic
- * grain size.
+ * radius size.
  * This implementation leverages [processes](https://doi.org/10.1016/j.engappai.2020.104081),
  * each device tries to propagate a "bubble of influence", overlapping bubbles compete,
  * the highest symmetryBreaker value of the competing participants is selected.
  *
  * @param uid  T, unique node identifier
  * @param symmetryBreaker  V, competitivity, higher values make their node a more likely leader. Must be Comparable<V>.
- * @param grain  num, maximum radius of the partition
+ * @param radius  num, maximum radius of the partition
  * @param metric () -> num, neighbor distance estimator, returns a field of numbers
  * @param distance (bool) -> num, finds the distance with the closest location where the provided input is true
  * @return  T, the id of the local leader
  */
-public def localLeaderElection(uid, symmetryBreaker, grain, metric, distance) {
+public def localLeaderElection(uid, symmetryBreaker, radius, metric, distance) {
 	let default = [uid, [symmetryBreaker, 0]]
 	share (lead, nbrLead <- default) {
 		let sources = [nbrLead]
 		let distances = alignedMap(
 			sources,
 			{ candidate, breakDist ->
-				candidate == uid || foldMin(POSITIVE_INFINITY, breakDist.get(1) + metric()) < grain
+				candidate == uid || foldMin(POSITIVE_INFINITY, breakDist.get(1) + metric()) < radius
 			},
 			{ candidate, breakDist ->
 				[foldMax(breakDist.get(0)), distance(uid == candidate && idOf(lead) == uid)]
 			},
 			[NEGATIVE_INFINITY, POSITIVE_INFINITY]
 		)
-		let closeEnough = distances.filter { distanceOf(it) < grain }
+		let closeEnough = distances.filter { distanceOf(it) < radius }
 		let best = closeEnough.fold(default) { a, b ->
 			if (tieBreakerOf(a) > tieBreakerOf(b)) { a } else { b }
 		}

--- a/protelis-lang/src/main/protelis/protelis/coord/sparsechoice.pt
+++ b/protelis-lang/src/main/protelis/protelis/coord/sparsechoice.pt
@@ -35,6 +35,47 @@ def randomUid() {
     }
 }
 
+def idOf(tuple) = tuple.get(0)
+def distanceOf(tuple) = tuple.get(1).get(1)
+def tieBreakerOf(tuple) = [tuple.get(1).get(0), tuple.get(0)]
+
+/**
+ * Devices compete against one another to become local leaders,
+ * resulting  in  a  random  Voronoi  partition  with  a  characteristic
+ * grain size.
+ * This implementation leverages [processes](https://doi.org/10.1016/j.engappai.2020.104081),
+ * each device tries to propagate a "bubble of influence", overlapping bubbles compete,
+ * the highest symmetryBreaker value of the competing participants is selected.
+ *
+ * @param uid  T, unique node identifier
+ * @param symmetryBreaker  V, competitivity, higher values make their node a more likely leader. Must be Comparable<V>.
+ * @param grain  num, maximum radius of the partition
+ * @param metric () -> num, neighbor distance estimator, returns a field of numbers
+ * @param distance (bool) -> num, finds the distance with the closest location where the provided input is true
+ * @return  T, the id of the local leader
+ */
+public def localLeaderElection(uid, symmetryBreaker, grain, metric, distance) {
+	let default = [uid, [symmetryBreaker, 0]]
+	share (lead, nbrLead <- default) {
+		let sources = [nbrLead]
+		let distances = alignedMap(
+			sources,
+			{ candidate, breakDist ->
+				candidate == uid || foldMin(POSITIVE_INFINITY, breakDist.get(1) + metric()) < grain
+			},
+			{ candidate, breakDist ->
+				[foldMax(breakDist.get(0)), distance(uid == candidate && idOf(lead) == uid)]
+			},
+			[NEGATIVE_INFINITY, POSITIVE_INFINITY]
+		)
+		let closeEnough = distances.filter { distanceOf(it) < grain }
+		let best = closeEnough.fold(default) { a, b ->
+			if (tieBreakerOf(a) > tieBreakerOf(b)) { a } else { b }
+		}
+		best
+	}.get(0)
+}
+
 /**
  * Devices compete against one another to become local leaders,
  * resulting  in  a  random  Voronoi  partition  with  a  characteristic
@@ -47,3 +88,4 @@ def randomUid() {
 public def S(grain, metric) {
     breakUsingUids(randomUid(), grain, metric)
 }
+


### PR DESCRIPTION
This pull request introduces a new implementation of S, which returns the id of the local leader. Competition is performed exploiting the abstraction in Protelis closest to [aggregate processes](https://doi.org/10.1016/j.engappai.2020.104081): `alignedMap`.
Devices propagate a "bubble", colliding bubbles compete based on a symmetry-breaker.

This implementation avoid convergence to cycles that may happen with the classic S implementation.

@jakebeal I would very much appreciate your opinion on the solution before going on and prepare tests. The implementation comes from [the experiments](https://github.com/DanySK/Experiment-2020-SCP-Graph-Statistics) performed by @harniver and I for [this publication](https://doi.org/10.1016/j.scico.2020.102584)