### PR TITLE
feat(interpreter)!: make ProtelisProgram immutable

### DIFF
--- a/protelis-interpreter/src/main/java/org/protelis/lang/ProtelisLoader.java
+++ b/protelis-interpreter/src/main/java/org/protelis/lang/ProtelisLoader.java
@@ -1,42 +1,22 @@
 /*
- * Copyright (C) 2021, Danilo Pianini and contributors listed in the project's build.gradle.kts or pom.xml file.
+ * Copyright (C) 2022, Danilo Pianini and contributors listed in the project's build.gradle.kts file.
  *
  * This file is part of Protelis, and is distributed under the terms of the GNU General Public License,
  * with a linking exception, as described in the file LICENSE.txt in this project's top directory.
  */
 package org.protelis.lang;
 
-import static org.protelis.lang.ProtelisLoadingUtilities.IT;
-import static org.protelis.lang.ProtelisLoadingUtilities.argumentsToExpressionStream;
-import static org.protelis.lang.ProtelisLoadingUtilities.referenceFor;
-import static org.protelis.lang.ProtelisLoadingUtilities.referenceListFor;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import com.google.common.base.Splitter;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.hash.Hashing;
+import com.google.inject.Injector;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -119,13 +99,29 @@ import org.protelis.vm.impl.SimpleProgramImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.ImmutableList;
-import com.google.common.hash.Hashing;
-import com.google.inject.Injector;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import static org.protelis.lang.ProtelisLoadingUtilities.IT;
+import static org.protelis.lang.ProtelisLoadingUtilities.argumentsToExpressionStream;
+import static org.protelis.lang.ProtelisLoadingUtilities.referenceFor;
+import static org.protelis.lang.ProtelisLoadingUtilities.referenceListFor;
 
 /**
  * Main entry-point class for loading/parsing Protelis programs.
@@ -149,13 +145,14 @@ public final class ProtelisLoader {
     );
     private static final Pattern REGEX_PROTELIS_MODULE = Pattern.compile("(?:\\w+:)*\\w+");
 
-    private static final LoadingCache<Resource, ImmutablePair<ProtelisModule, ProtelisAST<?>>> FLYWEIGHT = CacheBuilder
+    private static final LoadingCache<Resource, ProtelisProgram> FLYWEIGHT = CacheBuilder
         .newBuilder()
         .maximumSize(1000)
         .build(
-            new CacheLoader<Resource, ImmutablePair<ProtelisModule, ProtelisAST<?>>>() {
+            new CacheLoader<Resource, ProtelisProgram>() {
                 @Override
-                public ImmutablePair<ProtelisModule, ProtelisAST<?>> load(@Nonnull final Resource resource) {
+                @Nonnull
+                public ProtelisProgram load(@Nonnull final Resource resource) {
                     Objects.requireNonNull(resource);
                     if (!resource.getErrors().isEmpty()) {
                         final String moduleName = Optional.ofNullable(resource.getContents())
@@ -198,7 +195,7 @@ public final class ProtelisLoader {
                         "The provided resource does not contain any main program, and can not be executed.");
                     Diagnostician.INSTANCE.validate(root).getChildren()
                         .forEach(it -> LOGGER.warn("severity {}: {}", it.getSeverity(), it.getMessage()));
-                    return new ImmutablePair<>(root, Dispatch.block(root.getProgram()));
+                    return new SimpleProgramImpl(root, Dispatch.block(root.getProgram()));
                 }
             }
         );
@@ -282,8 +279,7 @@ public final class ProtelisLoader {
      */
     public static ProtelisProgram parse(@Nonnull final Resource resource) {
         try {
-            final ImmutablePair<ProtelisModule, ProtelisAST<?>> immutableProgram = FLYWEIGHT.get(resource);
-            return new SimpleProgramImpl(immutableProgram.left, immutableProgram.right);
+            return FLYWEIGHT.get(resource);
         } catch (Exception e) { // NOPMD: this is intentional.
             throw new IllegalArgumentException(e);
         }

--- a/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/AbstractPersistedTree.java
+++ b/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/AbstractPersistedTree.java
@@ -23,8 +23,7 @@ import org.protelis.vm.ExecutionContext;
  */
 public abstract class AbstractPersistedTree<S, T> extends AbstractProtelisAST<T> {
 
-    private static final long serialVersionUID = 457607604000217166L;
-    private transient S superscript;
+    private static final long serialVersionUID = 1;
 
     /**
      * @param metadata
@@ -54,8 +53,7 @@ public abstract class AbstractPersistedTree<S, T> extends AbstractProtelisAST<T>
      * @return the previous state, if present, or the state computed by ifAbsent otherwise
      */
     protected final S loadState(final ExecutionContext context, final Supplier<S> ifAbsent) {
-        superscript = context.getPersistent(ifAbsent);
-        return superscript;
+        return context.getPersistent(ifAbsent);
     }
 
     /**
@@ -66,19 +64,12 @@ public abstract class AbstractPersistedTree<S, T> extends AbstractProtelisAST<T>
      */
     protected final void saveState(final ExecutionContext context, final S obj) {
         context.setPersistent(obj);
-        superscript = obj;
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public String toString() {
-        return super.toString() + "{ "
-            + (superscript instanceof ProtelisAST
-                ? stringFor((ProtelisAST<?>) superscript)
-                : superscript == null ? "..." : superscript)
-            + " }";
-    }
+    public abstract String toString();
 
 }

--- a/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/Eval.java
+++ b/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/Eval.java
@@ -70,4 +70,9 @@ public final class Eval extends AbstractPersistedTree<Pair<String, ProtelisProgr
     private ProtelisAST<?> programText() {
         return getBranch(0);
     }
+
+    @Override
+    public String toString() {
+        return "eval(" + stringFor(getBranch(0)) + ")";
+    }
 }

--- a/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/Eval.java
+++ b/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/Eval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021, Danilo Pianini and contributors listed in the project's build.gradle.kts or pom.xml file.
+ * Copyright (C) 2022, Danilo Pianini and contributors listed in the project's build.gradle.kts file.
  *
  * This file is part of Protelis, and is distributed under the terms of the GNU General Public License,
  * with a linking exception, as described in the file LICENSE.txt in this project's top directory.
@@ -47,10 +47,9 @@ public final class Eval extends AbstractPersistedTree<Pair<String, ProtelisProgr
                 : createState(currentProgram);
         saveState(context, actualState);
         return context.runInNewStackFrame(EVAL_DYNAMIC_CODE.getCode(), ctx -> {
-            actualState.getRight().compute(ctx);
-        // TODO: figure out which references to pass down... and how to.
-//          context.putMultipleVariables(result.getGloballyAvailableReferences());
-            return actualState.getRight().getCurrentValue();
+            // TODO: figure out which references to pass down... and how to.
+            // context.putMultipleVariables(result.getGloballyAvailableReferences());
+            return actualState.getRight().compute(ctx);
         });
     }
 

--- a/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/ShareCall.java
+++ b/protelis-interpreter/src/main/java/org/protelis/lang/interpreter/impl/ShareCall.java
@@ -225,15 +225,15 @@ public final class ShareCall<S, T> extends AbstractPersistedTree<S, T> {
     public String toString() {
         final Optional<String> field = fieldName.transform(Reference::toString);
         return getName() + " ("
-                + localName.transform(Reference::toString)
+            + localName.transform(Reference::toString)
                 .transform(it -> it + field.transform(f -> ", ").or("")).or("")
-                + field.or("")
-                + " <- "
-                + stringFor(init)
-                + ") { "
-                + stringFor(body)
-                + " }"
-                + yield.transform(it -> " yield { " + stringFor(it) + '}').or("");
+            + field.or("")
+            + " <- "
+            + stringFor(init)
+            + ") { "
+            + stringFor(body)
+            + " }"
+            + yield.transform(it -> " yield { " + stringFor(it) + '}').or("");
     }
 
     private static <T> void ifPresent(final Optional<T> var, final Consumer<T> todo) {

--- a/protelis-interpreter/src/main/java/org/protelis/vm/ProtelisProgram.java
+++ b/protelis-interpreter/src/main/java/org/protelis/vm/ProtelisProgram.java
@@ -24,6 +24,8 @@ public interface ProtelisProgram extends Serializable {
     Object compute(ExecutionContext context);
 
     /**
+     * The name of the program.
+     *
      * @return Name of the program, or some default name if no specific name is
      *         provided
      */

--- a/protelis-interpreter/src/main/java/org/protelis/vm/ProtelisProgram.java
+++ b/protelis-interpreter/src/main/java/org/protelis/vm/ProtelisProgram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021, Danilo Pianini and contributors listed in the project's build.gradle.kts or pom.xml file.
+ * Copyright (C) 2022, Danilo Pianini and contributors listed in the project's build.gradle.kts file.
  *
  * This file is part of Protelis, and is distributed under the terms of the GNU General Public License,
  * with a linking exception, as described in the file LICENSE.txt in this project's top directory.
@@ -14,19 +14,14 @@ import java.io.Serializable;
 public interface ProtelisProgram extends Serializable {
 
     /**
-     * @return The value computed during the most recent invocation of
-     *         {@link ProtelisProgram#compute(ExecutionContext)}
-     */
-    Object getCurrentValue();
-
-    /**
      * Execute one round of computation of this Protelis program.
      * 
      * @param context
      *            The virtual machine environment in which computation will take
      *            place.
+     * @return the result of the program's evaluation
      */
-    void compute(ExecutionContext context);
+    Object compute(ExecutionContext context);
 
     /**
      * @return Name of the program, or some default name if no specific name is

--- a/protelis-interpreter/src/main/java/org/protelis/vm/ProtelisVM.java
+++ b/protelis-interpreter/src/main/java/org/protelis/vm/ProtelisVM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021, Danilo Pianini and contributors listed in the project's build.gradle.kts or pom.xml file.
+ * Copyright (C) 2022, Danilo Pianini and contributors listed in the project's build.gradle.kts file.
  *
  * This file is part of Protelis, and is distributed under the terms of the GNU General Public License,
  * with a linking exception, as described in the file LICENSE.txt in this project's top directory.
@@ -7,6 +7,10 @@
 package org.protelis.vm;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
 
 /**
  * A virtual machine for executing a Protelis program on a particular device
@@ -16,6 +20,8 @@ public class ProtelisVM {
 
     private final ProtelisProgram program;
     private final ExecutionContext context;
+
+    private @Nullable Object lastValue;
 
     /**
      * Create a virtual machine for executing a Protelis program in a particular
@@ -42,7 +48,7 @@ public class ProtelisVM {
         // 1. Take the messages received by neighbors
         context.setup();
         // 2. Compute
-        program.compute(context);
+        lastValue = program.compute(context);
         // 3. Finalize the new environment and send Messages away
         context.commit();
     }
@@ -52,8 +58,12 @@ public class ProtelisVM {
      * 
      * @return Last value computed
      */
+    @Nonnull
     public Object getCurrentValue() {
-        return program.getCurrentValue();
+        return Objects.requireNonNull(
+            lastValue,
+            "No computation has happened so far, so no result is available yet. Call 'runCycle()' first."
+        );
     }
 
 }

--- a/protelis-interpreter/src/main/java/org/protelis/vm/impl/SimpleProgramImpl.java
+++ b/protelis-interpreter/src/main/java/org/protelis/vm/impl/SimpleProgramImpl.java
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2021, Danilo Pianini and contributors listed in the project's build.gradle.kts or pom.xml file.
+ * Copyright (C) 2022, Danilo Pianini and contributors listed in the project's build.gradle.kts file.
  *
  * This file is part of Protelis, and is distributed under the terms of the GNU General Public License,
  * with a linking exception, as described in the file LICENSE.txt in this project's top directory.
- */
-/**
- * 
  */
 package org.protelis.vm.impl;
 
@@ -26,7 +23,6 @@ public final class SimpleProgramImpl implements ProtelisProgram {
     private static final String DEFAULT_PROGRAM_NAME = "default_module:default_program";
     private final ProtelisAST<?> prog;
     private final String name;
-    private Object result;
 
     /**
      * @param source
@@ -55,13 +51,8 @@ public final class SimpleProgramImpl implements ProtelisProgram {
     }
 
     @Override
-    public Object getCurrentValue() {
-        return result;
-    }
-
-    @Override
-    public void compute(final ExecutionContext context) {
-        result = prog.eval(context);
+    public Object compute(final ExecutionContext context) {
+        return prog.eval(context);
     }
 
     @Override


### PR DESCRIPTION
This commit makes Protelis immutable to the `ProtelisProgram` entry point. Mutability is now confined to `ProtelisVM` and `ExecutionContext`. In other words, while `ProtelisVM`s must be handled with care and not shared across structures and threads, entire Protelis programs (namely, abstract syntax trees and module names) can.