### PR TITLE
fix(protelis-lang): patch the code of the S block

### DIFF
--- a/protelis-lang/src/main/protelis/protelis/coord/sparsechoice.pt
+++ b/protelis-lang/src/main/protelis/protelis/coord/sparsechoice.pt
@@ -8,23 +8,25 @@ def default() {
 
 def breakUsingUids(uid, grain, metric) {
     share (lead, nbrLead <- uid) {
-        distanceCompetition(distanceToWithMetric(uid == lead, metric), nbrLead, uid, grain)
+        distanceCompetition(distanceToWithMetric(uid == lead, metric), nbrLead, uid, grain, metric)
     } == uid
 }
 
-def distanceCompetition(d, nbrLead, uid, grain) {
+def distanceCompetition(d, nbrLead, uid, grain, metric) {
     mux (d > grain) {
         uid
     } else {
-        let thr = 0.25 * grain;
+        let thr = 0.5 * grain;
         mux (d >= thr) {
             default()
         } else {
-            mux (d >= thr) {
-                default()
-            } else {
-                minHood PlusSelf(nbrLead)
-            }
+            foldMin(
+                mux (nbr(d) + metric() >= thr) {
+                    default()
+                } else {
+                    nbrLead
+                }
+            )
         }
     }
 }


### PR DESCRIPTION
S empirically used to exhibit non-self-stabilizing (oscillatory) behavior. The implementation differed from the one in the literature, and should now be aligned.