### PR TITLE
chore(test): fix typos in test messages

### DIFF
--- a/protelis-test/src/main/java/org/protelis/test/InfrastructureTester.java
+++ b/protelis-test/src/main/java/org/protelis/test/InfrastructureTester.java
@@ -102,7 +102,7 @@ public final class InfrastructureTester {
                     assertEquals(occ, found);
                 } catch (final AssertionError e) {
                     obs.exceptionThrown(
-                        new IllegalArgumentException("Expected occurences [" + occ + "] != Occurences found [" + found + "]")
+                        new IllegalArgumentException("Expected occurrences [" + occ + "] != occurrences found [" + found + "]")
                     );
                 }
             } else {

--- a/protelis-test/src/main/java/org/protelis/test/matcher/TestCount.java
+++ b/protelis-test/src/main/java/org/protelis/test/matcher/TestCount.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * Count the occurences of a given value.
+ * Count the occurrences of a given value.
  */
 public final class TestCount implements Function<Map<String, Object>, Integer> {
     private final Object expectedValue;


### PR DESCRIPTION
## Summary
- correct spelling in `TestCount` comment
- fix wording of error message for counting values

## Testing
- `./gradlew test` *(fails: could not download Gradle wrapper due to network)*