### PR TITLE
Update AGENTS commit guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Development Guidelines
+
+This repository uses [Conventional Commits](https://www.conventionalcommits.org) for all contributions.
+
+## Allowed Commit Types
+
+- `feat`: Use for new features. Any scope is allowed.
+- `chore(api-deps)`: Use when updating API dependencies.
+- `fix`: Use for bug fixes. Any scope is allowed.
+- `docs`: Use for documentation changes. Any scope is allowed.
+- `perf`: Use for performance improvements. Any scope is allowed.
+- `revert`: Use for reverting previous commits. Any scope is allowed.
+- `chore(core-deps)`: Use when updating core dependencies.
+- `test`: Use for changes related to tests.
+- `ci`: Use for changes related to continuous integration.
+- `build`: Use for changes related to the build system.
+- `chore(deps)`: Use when updating generic dependencies.
+- `chore`: Use for general maintenance with scopes other than the ones above.
+- `style`: Use for code style updates.
+- `refactor`: Use for refactoring existing code without changing behaviour.
+
+Any commit type or scope suffixed with `!` denotes a **BREAKING CHANGE**.
+
+## Scopes
+
+Valid scopes are the names of the Gradle modules of this project:
+`interpreter`, `lang`, and `test`.
+If a change spans multiple modules or modifies the root project, the scope may be omitted.
+The dependency update scopes `api-deps`, `core-deps`, and `deps` are also allowed for the `chore` type.
+
+## Verification
+
+Before submitting a pull request, verify the project builds successfully:
+
+```bash
+./gradlew build assemble
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,11 @@ Valid scopes are the names of the Gradle modules of this project:
 If a change spans multiple modules or modifies the root project, the scope may be omitted.
 The dependency update scopes `api-deps`, `core-deps`, and `deps` are also allowed for the `chore` type.
 
+## Pull requests
+
+Pull request titles should be formatted as conventional commits.
+A typical good pull request will contain a single commit whose message first line is the same of the PR title.
+
 ## Verification
 
 Before submitting a pull request, verify the project builds successfully:


### PR DESCRIPTION
## Summary
- adjust allowed commit scopes to omit `protelis-` prefix
- remove release information from commit type table

## Testing
- `./gradlew build assemble` *(fails: No route to host)*