### PR TITLE
docs(test): clarify javadoc wording

### DIFF
--- a/protelis-test/src/main/java/org/protelis/test/ProgramTester.java
+++ b/protelis-test/src/main/java/org/protelis/test/ProgramTester.java
@@ -208,7 +208,7 @@ public final class ProgramTester {
      * @param file
      *            file to be tested
      * @param stream
-     *            stream of run
+     *            stream of runs
      */
     public static void runFileWithMultipleRuns(final String file, final IntStream stream) {
         stream.forEach(i -> runFile(file, i));


### PR DESCRIPTION
## Summary
- fix typo in Javadoc for `runFileWithMultipleRuns`

## Testing
- `gradle --offline javadoc` *(fails: Plugin com.gradle.develocity could not be resolved)*
- `gradle --offline build assemble` *(fails: Plugin com.gradle.develocity could not be resolved)*
