### PR TITLE
fix(interpreter): lazily evaluate Option.orElseGet

### DIFF
--- a/protelis-interpreter/src/main/java/org/protelis/lang/datatype/Option.java
+++ b/protelis-interpreter/src/main/java/org/protelis/lang/datatype/Option.java
@@ -397,7 +397,7 @@ public final class Option<E> implements Serializable {
      * @return the value if present otherwise the result of {@code other.get()}
      */
     public E orElseGet(final Supplier<? extends E> other) {
-        return internal.or(other.get());
+        return internal.or(other::get);
     }
 
     /**


### PR DESCRIPTION
## Summary
- avoid prematurely invoking suppliers in `Option.orElseGet`

## Testing
- `./gradlew build assemble --offline`